### PR TITLE
enable import pyFDN

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,35 +67,29 @@ editable mode together with the optional tooling::
 Quick start
 -----------
 
-.. The snippet below sketches the main steps involved in assembling a simple
-.. four-delay FDN and inspecting its stability bounds::
+All main functions are accessible directly from the top-level ``pyFDN`` namespace::
 
-..     from types import SimpleNamespace
-..     import numpy as np
-..     from pyFDN.generate.random_orthogonal import random_orthogonal
-..     from pyFDN.auxiliary.one_pole_absorption import one_pole_absorption
-..     from pyFDN.auxiliary.pole_boundaries import pole_boundaries
+    import numpy as np
+    import pyFDN
 
-..     fs = 48_000
-..     delays = np.array([331, 347, 359, 373], dtype=int)
+    fs = 48_000
+    delays = np.array([331, 347, 359, 373], dtype=int)
 
-..     # Energy-preserving feedback matrix (shape: N x N x 1)
-..     feedback = random_orthogonal(len(delays))[..., np.newaxis]
+    # energy-preserving feedback matrix
+    feedback = pyFDN.random_orthogonal(len(delays))
 
-..     # Match-loop decay targets (seconds) at DC and Nyquist
-..     rt60 = np.full(len(delays), 0.6)
-..     sos = one_pole_absorption(rt60, 1.4 * rt60, delays, fs)  # SOS format: (6, N)
-..     # Convert SOS to b, a format for pole_boundaries: b shape (N, 1, 1), a shape (N, 1, 2)
-..     b = sos[0:1, :].T[:, np.newaxis, :]  # b0, shape (N, 1, 1)
-..     a = np.stack([sos[3, :], sos[4, :]], axis=1)[:, np.newaxis, :]  # [a0, a1], shape (N, 1, 2)
-..     absorption = SimpleNamespace(b=b, a=a)
+    # one-pole absorption filters targeting rt60 of 1.2s at dc and 0.9s at nyquist
+    absorption = pyFDN.one_pole_absorption(1.2, 0.9, delays, fs)
 
-..     lower, upper, freqs = pole_boundaries(delays, absorption, feedback, fs)
-..     print(f"Stability window @ {freqs[0]:.1f} Hz: {lower[0]:.3f} – {upper[0]:.3f}")
+    # convert delay state-space to standard state-space
+    ss_matrix, b, c, d = pyFDN.dss2ss(delays, feedback)
 
-.. For matrix-polynomial manipulation without SciPy, the :mod:`pyFDN.auxiliary`
-.. package exposes convenience functions such as ``matrix_convolution``,
-.. ``matrix_polyval``, and ``TFMatrix``.
+Alternatively, import specific functions directly::
+
+    from pyFDN import random_orthogonal, one_pole_absorption, mag2db
+
+    feedback = random_orthogonal(4)
+    absorption = one_pole_absorption(1.2, 0.9, [100, 150, 200, 250], 48_000)
 
 
 .. Repository index

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,6 +2,16 @@
 Usage
 =====
 
-To use pyFDN in a project::
+All main functions are accessible directly from ``pyFDN``::
 
     import pyFDN
+
+    feedback = pyFDN.random_orthogonal(4)
+    absorption = pyFDN.one_pole_absorption(1.2, 0.9, [100, 150, 200, 250], 48_000)
+    gain_db = pyFDN.mag2db([0.5, 1.0, 2.0])
+
+Or import specific functions::
+
+    from pyFDN import random_orthogonal, one_pole_absorption, dss2ss
+
+    feedback = random_orthogonal(4)

--- a/examples/example_absorption_filters.ipynb
+++ b/examples/example_absorption_filters.ipynb
@@ -9,10 +9,7 @@
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
-    "from pyFDN.auxiliary.absorption_to_t60 import absorption_to_t60\n",
-    "from pyFDN.auxiliary.absorption_filters import absorption_filters\n",
-    "from pyFDN.auxiliary.ms2smp import ms2smp\n",
+    "import pyFDN\n",
     "\n",
     "# ---------------- Example run ---------------- #\n",
     "if __name__ == \"__main__\":\n",
@@ -22,13 +19,13 @@
     "    targetT60 = np.vstack([targetT60[0, :], targetT60, targetT60[-1, :]])\n",
     "\n",
     "    delayTime = [20, 40]  # ms\n",
-    "    delays = ms2smp(delayTime, fs)\n",
+    "    delays = pyFDN.ms2smp(delayTime, fs)\n",
     "\n",
     "    filterLength = 10  # ms\n",
-    "    filterOrder = 2 ** int(np.ceil(np.log2(ms2smp(filterLength, fs))))\n",
+    "    filterOrder = 2 ** int(np.ceil(np.log2(pyFDN.ms2smp(filterLength, fs))))\n",
     "\n",
-    "    coeffs = absorption_filters(targetFrequency, targetT60, filterOrder, delays, fs)\n",
-    "    T60, T60_f = absorption_to_t60(coeffs, np.array(delays), 2**10, fs)\n",
+    "    coeffs = pyFDN.absorption_filters(targetFrequency, targetT60, filterOrder, delays, fs)\n",
+    "    T60, T60_f = pyFDN.absorption_to_t60(coeffs, np.array(delays), 2**10, fs)\n",
     "\n",
     "    # Plot filters\n",
     "    plt.figure()\n",
@@ -53,7 +50,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "seb312",
    "language": "python",
    "name": "python3"
   },
@@ -67,7 +64,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/examples/example_dss2ss.ipynb
+++ b/examples/example_dss2ss.ipynb
@@ -2,34 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "39bb736c",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "matmul: Input operand 1 has a mismatch in its core dimension 0, with gufunc signature (n?,k),(k,m?)->(n?,m?) (size 1 is different from 3)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 48\u001b[39m\n\u001b[32m     45\u001b[39m     irStateSpace_SOS += np.squeeze(ir_s)\n\u001b[32m     47\u001b[39m \u001b[38;5;66;03m# Delay state-space impulse response\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m48\u001b[39m irDelayStateSpace = \u001b[43mdss2impz\u001b[49m\u001b[43m(\u001b[49m\u001b[43mimpulseResponseLength\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mm\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mA\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mb\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43md\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     50\u001b[39m \u001b[38;5;66;03m# Plot\u001b[39;00m\n\u001b[32m     51\u001b[39m plt.figure()\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Documents/ss25/pyFDN/src/pyFDN/translate/dss2impz.py:42\u001b[39m, in \u001b[36mdss2impz\u001b[39m\u001b[34m(ir_len, delays, A, B, C, D, input_type, extra_matrix, absorption_filters)\u001b[39m\n\u001b[32m     39\u001b[39m input_signal[\u001b[32m0\u001b[39m, :] = \u001b[32m1\u001b[39m\n\u001b[32m     41\u001b[39m \u001b[38;5;66;03m# Process FDN\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m42\u001b[39m impulse_response = \u001b[43mprocessFDN\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     43\u001b[39m \u001b[43m    \u001b[49m\u001b[43minput_signal\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     44\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdelays\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     45\u001b[39m \u001b[43m    \u001b[49m\u001b[43mA\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     46\u001b[39m \u001b[43m    \u001b[49m\u001b[43mB\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     47\u001b[39m \u001b[43m    \u001b[49m\u001b[43mC\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     48\u001b[39m \u001b[43m    \u001b[49m\u001b[43mD\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     49\u001b[39m \u001b[43m    \u001b[49m\u001b[43minput_type\u001b[49m\u001b[43m=\u001b[49m\u001b[43minput_type\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     50\u001b[39m \u001b[43m    \u001b[49m\u001b[43mextra_matrix\u001b[49m\u001b[43m=\u001b[49m\u001b[43mextra_matrix\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     51\u001b[39m \u001b[43m    \u001b[49m\u001b[43mabsorption_filters\u001b[49m\u001b[43m=\u001b[49m\u001b[43mabsorption_filters\u001b[49m\n\u001b[32m     52\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     54\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m impulse_response\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Documents/ss25/pyFDN/src/pyFDN/auxiliary/processFDN.py:69\u001b[39m, in \u001b[36mprocessFDN\u001b[39m\u001b[34m(input_signal, delays, A, B, C, D, input_type, extra_matrix, absorption_filters)\u001b[39m\n\u001b[32m     67\u001b[39m     in_block = np.zeros_like(input_signal)\n\u001b[32m     68\u001b[39m     in_block[:, it_in] = input_signal[:, it_in]\n\u001b[32m---> \u001b[39m\u001b[32m69\u001b[39m     output[:, :, it_in] = \u001b[43mcomputeFDNloop\u001b[49m\u001b[43m(\u001b[49m\u001b[43min_block\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdelays\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfeedback_matrix\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43minput_gains\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43moutput_gains\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mextra_matrix\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mabsorption_filters\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     70\u001b[39m \u001b[38;5;66;03m# Add direct path\u001b[39;00m\n\u001b[32m     71\u001b[39m D = np.array(D).reshape(output.shape[\u001b[32m1\u001b[39m], output.shape[\u001b[32m2\u001b[39m])  \u001b[38;5;66;03m# [out, in]\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Documents/ss25/pyFDN/src/pyFDN/auxiliary/processFDN.py:113\u001b[39m, in \u001b[36mcomputeFDNloop\u001b[39m\u001b[34m(input_signal, delays, feedback_matrix, input_gains, output_gains, extra_matrix, absorption_filters)\u001b[39m\n\u001b[32m    110\u001b[39m     feedback = extra_matrix.filter(feedback)\n\u001b[32m    112\u001b[39m \u001b[38;5;66;03m# Input + feedback\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m113\u001b[39m delay_line_input = \u001b[43minput_gains\u001b[49m\u001b[43m.\u001b[49m\u001b[43mfilter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mblock\u001b[49m\u001b[43m)\u001b[49m + feedback\n\u001b[32m    114\u001b[39m delay_filters.set_values(delay_line_input)\n\u001b[32m    116\u001b[39m \u001b[38;5;66;03m# Compute output\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Documents/ss25/pyFDN/src/pyFDN/dsp/dfiltmatrix.py:56\u001b[39m, in \u001b[36mDFiltMatrix.filter\u001b[39m\u001b[34m(self, x)\u001b[39m\n\u001b[32m     54\u001b[39m         out = x * \u001b[38;5;28mself\u001b[39m.filters\n\u001b[32m     55\u001b[39m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m56\u001b[39m         out = \u001b[43mx\u001b[49m\u001b[43m \u001b[49m\u001b[43m@\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mfilters\u001b[49m\u001b[43m.\u001b[49m\u001b[43mT\u001b[49m\n\u001b[32m     57\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m     58\u001b[39m     \u001b[38;5;66;03m# Object filters (ZFilter)\u001b[39;00m\n\u001b[32m     59\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.is_diagonal:\n",
-      "\u001b[31mValueError\u001b[39m: matmul: Input operand 1 has a mismatch in its core dimension 0, with gufunc signature (n?,k),(k,m?)->(n?,m?) (size 1 is different from 3)"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy.signal import ss2tf, tf2sos, dlti, dimpulse\n",
+    "import pyFDN\n",
     "\n",
-    "from pyFDN.generate.random_orthogonal import random_orthogonal\n",
-    "from pyFDN.translate.dss2impz import dss2impz\n",
-    "from pyFDN.translate.dss2ss import dss2ss\n",
     "\n",
     "def isAlmostZero(x, tol=1e-12):\n",
     "    return np.all(np.abs(x) < tol)\n",
@@ -42,13 +24,13 @@
     "N = 3\n",
     "m = np.array([13, 19, 23])\n",
     "g = 0.9\n",
-    "A = random_orthogonal(N) @ np.diag(g ** m)\n",
+    "A = pyFDN.random_orthogonal(N) @ np.diag(g ** m)\n",
     "b = np.random.randn(N, 1)\n",
     "c = np.random.randn(1, N)\n",
     "d = np.random.randn(1, 1)\n",
     "\n",
     "# State-space transition matrix\n",
-    "AA, bb, cc, dd = dss2ss(m, A, b, c, d)\n",
+    "AA, bb, cc, dd = pyFDN.dss2ss(m, A, b, c, d)\n",
     "\n",
     "# Compare impulse response\n",
     "impulseResponseLength = 100\n",
@@ -70,7 +52,7 @@
     "    irStateSpace_SOS += np.squeeze(ir_s)\n",
     "    \n",
     "# Delay state-space impulse response\n",
-    "irDelayStateSpace = dss2impz(impulseResponseLength, m, A, b, c, d)\n",
+    "irDelayStateSpace = pyFDN.dss2impz(impulseResponseLength, m, A, b, c, d, input_type='mergeInput') # TODO: change to splitInput\n",
     "\n",
     "# Plot\n",
     "plt.figure()\n",
@@ -99,7 +81,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "seb312",
    "language": "python",
    "name": "python3"
   },
@@ -113,7 +95,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/src/pyFDN/__init__.py
+++ b/src/pyFDN/__init__.py
@@ -1,5 +1,120 @@
 """Top-level package for pyFDN."""
 
-__author__ = """Kalyan Pandey"""
-__email__ = "pandey.kalyan416@gmail.com"
+__author__ = "Facundo Franchino"
 __version__ = "0.1.0"
+
+__all__ = [
+    # filter classes
+    "DFiltMatrix",
+    "FeedbackDelay",
+    "FilterMatrix",
+    "TFMatrix",
+    "ZFIR",
+    "ZFilter",
+    "ZSOS",
+    "ZScalar",
+    "ZTF",
+    # acoustics
+    "absorption_filters",
+    "absorption_to_t60",
+    "one_pole_absorption",
+    "rt60_to_slope",
+    "slope_to_rt60",
+    # delay utilities
+    "matrix_delay_approximation",
+    "mgrpdelay",
+    "ms2smp",
+    # matrix generators
+    "construct_cascaded_paraunitary_matrix",
+    "construct_velvet_feedback_matrix",
+    "is_almost_zero",
+    "random_matrix_shift",
+    "random_orthogonal",
+    "shift_matrix",
+    "shift_matrix_distribute",
+    # polynomial and matrix maths
+    "det_polynomial",
+    "matrix_convolution",
+    "matrix_polyder",
+    "matrix_polyval",
+    "negpolyder",
+    "outer_sum_approximation",
+    "poly_degree",
+    "polyder_rational",
+    "polydiag",
+    # general utilities
+    "db2mag",
+    "ensure_3d",
+    "hertz2unit",
+    "is_bounding_curve",
+    "last_nonzero_indices",
+    "mag2db",
+    "pole_boundaries",
+    # state-space translators
+    "dss2impz",
+    "dss2ss",
+    # fdn processing
+    "process_fdn",
+]
+
+#acoustics and absorption
+from .auxiliary.acoustics import (
+    absorption_filters,
+    absorption_to_t60,
+    one_pole_absorption,
+    rt60_to_slope,
+    slope_to_rt60,
+)
+
+#delay utilities
+from .auxiliary.delay import matrix_delay_approximation, mgrpdelay, ms2smp
+
+# filter classes
+from .auxiliary.filters import TFMatrix, ZFIR, ZFilter, ZScalar, ZSOS, ZTF
+
+#polynomial and matrix maths
+from .auxiliary.math import (
+    det_polynomial,
+    matrix_convolution,
+    matrix_polyder,
+    matrix_polyval,
+    negpolyder,
+    outer_sum_approximation,
+    poly_degree,
+    polyder_rational,
+    polydiag,
+)
+
+#general utilities
+from .auxiliary.utils import (
+    db2mag,
+    ensure_3d,
+    hertz2unit,
+    is_bounding_curve,
+    last_nonzero_indices,
+    mag2db,
+    pole_boundaries,
+)
+
+#matrix generators
+from .generate.random_orthogonal import random_orthogonal
+from .generate.random_matrix_shift import random_matrix_shift
+from .generate.shift_matrix import shift_matrix
+from .generate.shift_matrix_distribute import shift_matrix_distribute
+from .generate.construct_cascaded_paraunitary_matrix import (
+    construct_cascaded_paraunitary_matrix,
+)
+from .generate.construct_velvet_feedback_matrix import construct_velvet_feedback_matrix
+from .generate.is_almost_zero import is_almost_zero
+
+#state-space translators
+from .translate.dss2ss import dss2ss
+from .translate.dss2impz import dss2impz
+
+#fdn processing
+from .process import process_fdn
+
+#dsp components
+from .dsp.filter_matrix import FilterMatrix
+from .dsp.feedback_delay import FeedbackDelay
+from .dsp.dfiltmatrix import DFiltMatrix


### PR DESCRIPTION
## simplify library imports (librosa style)                                        
                          
                                                                                
  as discussed in the meeting and mentioned in my issue, the old import style wasn’t very straightforward:                                             
                                                                                
  ```python                                                                     
  from pyFDN.auxiliary.one_pole_absorption import one_pole_absorption           
  from pyFDN.generate.random_orthogonal import random_orthogonal                
  ```                                                                           
                                                                                
  now you can do:                                                               
                                                                                
  ```python                                                                     
  import pyFDN                                                                  
                                                                                
  feedback = pyFDN.random_orthogonal(4)                                         
  absorption = pyFDN.one_pole_absorption(1.2, 0.9, delays, 48000)               
  ```                                                                           
                                                                                
  or:                                                                           
                                                                                
  ```python                                                                     
  from pyFDN import random_orthogonal, one_pole_absorption                      
  ```                                                                           
                                                                                
  like librosa does basically                                                   
                                                                                
  ### changes                                                                   
  - updated `__init__.py` to export all public functions/classes                
  - added `__all__` so autocomplete only shows the 43 public items (not internal
   submodules)                                                                  
  - updated README and docs/usage.rst with examples showing new import style    
                                                                                
  no internal restructuring, just exposing what was already there. old import   
  paths still work if anyone was using them