### PR TITLE
fix: install libsndfile1 in docs CI to resolve configuration error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,10 @@ jobs:
         with:
           python-version: '3.11'
 
+      # Install system libraries required by soundfile (via flamo)
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsndfile1
+
       # Install Sphinx and dependencies
       - name: Install dependencies
         run: |

--- a/docs/examples
+++ b/docs/examples
@@ -1,0 +1,1 @@
+/Users/cucu/Documents/GitHub/pyFDN/examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "watchdog>=3.0.0",  # development tools
 ]
 docs = [
-    "Sphinx>=6.0.0,<9.0.0",  # documentation
+    "Sphinx>=6.0.0",  # documentation
     "sphinx-rtd-theme>=1.0.0",  # documentation theme
     "sphinx-autodoc-typehints>=1.0.0",  # documentation type hints
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "watchdog>=3.0.0",  # development tools
 ]
 docs = [
-    "Sphinx>=6.0.0",  # documentation
+    "Sphinx>=6.0.0,<9.0.0",  # documentation
     "sphinx-rtd-theme>=1.0.0",  # documentation theme
     "sphinx-autodoc-typehints>=1.0.0",  # documentation type hints
 ]


### PR DESCRIPTION
The docs build failed with "Configuration error!" because conf.py imports pyFDN, which pulls in flamo → soundfile, requiring the libsndfile1 system library. This wasn't installed on the GHA runner.