### PR TITLE
restore docs deployment job and allow manual triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,12 +2,13 @@ name: Docs CI
 
 # Trigger automatically on push or PR + manual trigger
 on:
-  workflow_dispatch:      # manual trigger
+  workflow_dispatch:       # manual trigger
   push:
-    branches: [ main ]  # optional automatic build
+    branches: [ main ]    # optional automatic build
     paths:
       - 'src/**'
       - 'docs/**'
+      - '.github/workflows/docs.yml'
   pull_request:
     branches: [ main ]
 
@@ -49,7 +50,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip --no-cache-dir
           pip install --no-cache-dir ".[docs]" graphviz
-
+      
       # Auto-generate .rst files from source
       - name: Generate Sphinx RST
         run: |
@@ -59,3 +60,45 @@ jobs:
       - name: Build HTML docs
         working-directory: docs
         run: make html
+
+      # Save built docs as an artifact for later deployment
+      - name: Upload built docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: docs/_build/html
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: build-docs
+    # Only deploy on pushes to main so environment rules are satisfied
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      # Configure Pages
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        with:
+          enablement: true
+
+      # Download the built docs from the previous job
+      - name: Download docs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-html
+          path: docs/_build/html
+
+      # Upload artifact for GitHub Pages
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+      # Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- restored the missing deploy-docs job, added the manual trigger (workflow_dispatch) to the allowed deployment events so one can easilu force a manual deploy in the future.
- added  .github/workflows/docs.yml to the path list so it triggers automatically