### PR TITLE
Fix Marimo notebook link paths of allPass examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,32 +11,6 @@ sys.path.insert(
 
 import pyFDN  # noqa: E402
 
-# # -- Symlink examples into docs so nbsphinx can find them --------------------
-# # Use real dir + per-notebook symlinks to avoid nbsphinx image path issues (GH#49)
-# _docs_dir = os.path.dirname(os.path.abspath(__file__))
-# _examples_src = os.path.join(os.path.dirname(_docs_dir), "examples")
-# _examples_dst = os.path.join(_docs_dir, "examples")
-# if os.path.islink(_examples_dst):
-#     os.unlink(_examples_dst)
-# if not os.path.exists(_examples_dst):
-#     os.makedirs(_examples_dst, exist_ok=True)
-# for root, _dirs, files in os.walk(_examples_src):
-#     rel = os.path.relpath(root, _examples_src)
-#     if rel != ".":
-#         dst_sub = os.path.join(_examples_dst, rel)
-#         os.makedirs(dst_sub, exist_ok=True)
-#     for f in files:
-#         if f.endswith(".py"):
-#             src_file = os.path.join(root, f)
-#             dst_file = (
-#                 os.path.join(_examples_dst, rel, f)
-#                 if rel != "."
-#                 else os.path.join(_examples_dst, f)
-#             )
-#             if os.path.exists(dst_file):
-#                 os.unlink(dst_file)
-#             os.symlink(os.path.relpath(src_file, os.path.dirname(dst_file)), dst_file)
-
 # -- Project information ------------------------------------------------------
 project = "pyFDN"
 copyright = "2026, Artificial Audio Lab"
@@ -52,7 +26,6 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
-    # "nbsphinx",
     "sphinx_design",
     "sphinx_copybutton",
     "sphinx_autodoc_typehints",
@@ -68,23 +41,6 @@ autosummary_imported_members = True
 napoleon_google_docstring = True
 napoleon_numpy_docstring = True
 
-# # nbsphinx settings
-# nbsphinx_execute = "auto"  # Execute notebooks that have no stored outputs
-# nbsphinx_allow_errors = False
-# nbsphinx_prolog = """
-# {% set docname = env.doc2path(env.docname, base=None) %}
-
-# .. only:: html
-
-#     .. role:: raw-html(raw)
-#         :format: html
-
-#     .. note::
-
-#         | This page was generated from a Jupyter notebook.
-#         | :raw-html:`<a href="https://github.com/artificial-audio/pyFDN/blob/main/{{ docname }}"><img src="https://img.shields.io/badge/GitHub-view%20source-blue?logo=github" alt="View on GitHub"></a>`
-#         | :raw-html:`<a href="{{ env.docname.split('/')[-1] }}.ipynb" download><img src="https://img.shields.io/badge/Download-notebook-orange?logo=jupyter" alt="Download notebook"></a>`
-# """
 
 # Intersphinx mapping
 intersphinx_mapping = {
@@ -98,7 +54,7 @@ intersphinx_mapping = {
 source_suffix = ".rst"
 master_doc = "index"
 language = "en"
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # Pygments
 pygments_style = "friendly"

--- a/docs/examples_gallery.rst
+++ b/docs/examples_gallery.rst
@@ -73,23 +73,23 @@ Allpass FDN Examples
    :widths: 35 65
    :header-rows: 0
 
-   * - `Allpass FDN Completion <_static/marimo/notebooks/allpass_FDN/example_allpass_FDN_completion.html>`_
+   * - `Allpass FDN Completion <_static/marimo/notebooks/allpass_FDN_example_allpass_FDN_completion.html>`_
      - Construct ``b``, ``c``, and ``d`` for a given feedback matrix so the FDN becomes uniallpass.
-   * - `Homogeneous Allpass (MIMO) <_static/marimo/notebooks/allpass_FDN/example_allpass_FDN_homogeneous_mimo.html>`_
+   * - `Homogeneous Allpass (MIMO) <_static/marimo/notebooks/allpass_FDN_example_allpass_FDN_homogeneous_mimo.html>`_
      - MIMO allpass FDN with homogeneous decay, giving every pole the same decay rate with extra degrees of freedom.
-   * - `Homogeneous Allpass (SISO) <_static/marimo/notebooks/allpass_FDN/example_allpass_FDN_homogeneous_siso.html>`_
+   * - `Homogeneous Allpass (SISO) <_static/marimo/notebooks/allpass_FDN_example_allpass_FDN_homogeneous_siso.html>`_
      - SISO allpass FDN with homogeneous decay so all poles share the same decay rate.
-   * - `Allpass FDN in FDN <_static/marimo/notebooks/allpass_FDN/example_allpass_FDN_in_FDN.html>`_
+   * - `Allpass FDN in FDN <_static/marimo/notebooks/allpass_FDN_example_allpass_FDN_in_FDN.html>`_
      - Embed an allpass MIMO FDN inside a larger FDN loop, with single input and stereo output.
-   * - `Nested Allpass (Gardner) <_static/marimo/notebooks/allpass_FDN/example_allpass_FDN_nested.html>`_
+   * - `Nested Allpass (Gardner) <_static/marimo/notebooks/allpass_FDN_example_allpass_FDN_nested.html>`_
      - Gardner's nested allpass structure, built by iteratively nesting feedforward/back allpass sections.
-   * - `Allpass but not Uniallpass <_static/marimo/notebooks/allpass_FDN/example_allpass_FDN_not_uniallpass.html>`_
+   * - `Allpass but not Uniallpass <_static/marimo/notebooks/allpass_FDN_example_allpass_FDN_not_uniallpass.html>`_
      - An FDN that is allpass only for specific delay lengths, built via a non-diagonal similarity transform.
-   * - `Poletti's Allpass (MIMO) <_static/marimo/notebooks/allpass_FDN/example_allpass_FDN_poletti.html>`_
+   * - `Poletti's Allpass (MIMO) <_static/marimo/notebooks/allpass_FDN_example_allpass_FDN_poletti.html>`_
      - Poletti's unitary MIMO reverberator for reduced colouration in assisted reverberation systems.
-   * - `Schroeder Series Allpass <_static/marimo/notebooks/allpass_FDN/example_allpass_FDN_schroeder.html>`_
+   * - `Schroeder Series Allpass <_static/marimo/notebooks/allpass_FDN_example_allpass_FDN_schroeder.html>`_
      - Schroeder's cascade of first-order allpass sections realised as an FDN with diagonal feedback.
-   * - `Schroeder Allpass in Loop <_static/marimo/notebooks/allpass_FDN/example_allpass_FDN_schroeder_in_loop.html>`_
+   * - `Schroeder Allpass in Loop <_static/marimo/notebooks/allpass_FDN_example_allpass_FDN_schroeder_in_loop.html>`_
      - Place Schroeder allpass filters behind the delays in the FDN loop to increase echo density, rendered with FLAMO.
 
 ----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,6 @@ disable_error_code = ["no-untyped-call", "no-untyped-def", "override", "arg-type
 module = "pyFDN.auxiliary.acoustics"
 disable_error_code = ["operator", "index", "arg-type"]
 
-# Configure the max output size in Marimo nootebooks
+# Configure the max output size in Marimo notebooks
 [tool.marimo.runtime]
 output_max_bytes = 80_000_000


### PR DESCRIPTION
## Summary and Changes
- Fixed incorrect paths formatting that broke nested notebook links on pyFDN documentation website
- Fixed typo in ```pyproject.toml``` file
- Removed unnecessary inline comments from ```conf.py``` file

## Testing
- [ ] `pytest` passes locally
- [ ] New tests added for new functionality
- [ ] Coverage not decreased (`pytest --cov=pyFDN`)

## Checklist
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Docstrings updated for any changed public API
- [ ] `HISTORY.rst` updated if this is a user-facing change
