### PR TITLE
Translate Time-Varying Matrix from MATLAB to Python & Refactor process_fdn API

### DIFF
--- a/docs/examples_gallery.rst
+++ b/docs/examples_gallery.rst
@@ -118,6 +118,8 @@ FDN Design & Analysis
      - Statistics of the modal decomposition of a random FDN. The pole angles are almost equidistributed on the unit circle, while the residue magnitudes are spread across a large range.
    * - `Scattering feedback matrices <_static/marimo/notebooks/example_scattering_fdn.html>`_
      - Demonstration of different types of scattering (FIR paraunitary) feedback matrices from ``filter_matrix_gallery``:
+   * - `Time Varying FDN <_static/marimo/notebooks/example_time_varying_fdn.html>`_
+     - Open the rendered marimo notebook.
    * - `Time-domain FDN vs FLAMO with GEQ absorption <_static/marimo/notebooks/example_process_fdn_vs_flamo.html>`_
      - The same FDN with frequency-dependent absorption is rendered by two independent implementations and the impulse responses are compared:
 

--- a/examples/example_process_fdn_vs_flamo.py
+++ b/examples/example_process_fdn_vs_flamo.py
@@ -2,7 +2,7 @@
 
 import marimo
 
-__generated_with = "0.23.6"
+__generated_with = "0.23.9"
 app = marimo.App()
 
 
@@ -113,6 +113,9 @@ def _(delays, fs, go, np, num_delays, pyFDN, target_rt):
     sos_absorption = pyFDN.absorption_geq(target_rt, delays, fs)
     print(f"Absorption SOS shape: {sos_absorption.shape}")
 
+    # constract the SOSFilter
+    absorption = pyFDN.SOSFilterBank(sos_absorption, len(delays))
+
     fig_mag = go.Figure()
     for _i in range(num_delays):
         _, _H_bands, _W_bands = pyFDN.probe_sos(
@@ -140,7 +143,7 @@ def _(delays, fs, go, np, num_delays, pyFDN, target_rt):
         height=400,
     )
     fig_mag.show()
-    return (sos_absorption,)
+    return absorption, sos_absorption
 
 
 @app.cell(hide_code=True)
@@ -160,6 +163,7 @@ def _(mo):
 
 @app.cell
 def _(
+    absorption,
     delays,
     direct,
     feedback_matrix,
@@ -181,7 +185,7 @@ def _(
         input_gain,
         output_gain,
         direct,
-        absorption_filters=sos_absorption,
+        absorption=absorption,
     )
 
     model = pyFDN.dss_to_flamo(

--- a/examples/example_time_varying_fdn.py
+++ b/examples/example_time_varying_fdn.py
@@ -41,7 +41,6 @@ def _(mo):
 
 @app.cell
 def _():
-    import matplotlib.pyplot as plt
     import numpy as np
     import scipy.linalg as la
 
@@ -56,7 +55,6 @@ def _():
         la,
         np,
         one_pole_absorption,
-        plt,
         process_fdn,
         pyFDN,
         random_orthogonal,
@@ -72,22 +70,34 @@ def _(mo):
 
 
 @app.cell
-def _(mo, np, pyFDN):
+def _(mo):
+    sound_selection = mo.ui.dropdown(
+        options=["sine", "melody"],
+        value="melody",
+        label="Sound",
+    )
+    mo.output.replace(sound_selection)
+    return (sound_selection,)
+
+
+@app.cell
+def _(mo, np, pyFDN, sound_selection):
     np.random.seed(1)
 
     # init source signal
-    mode = "melody"
-    _output = None
+    mode = sound_selection.value
 
     if mode == "sine":
         fs = 48000
-        time = np.linspace(0, 4, 4 * fs)[:, None]
+        duration = 4
+        time = np.linspace(0, duration, duration * fs)[:, None]
 
         synth1 = 0.5 * np.sin(time * 440 * 2 * np.pi)
         synth2 = 0.5 * np.sin(time * 660 * 2 * np.pi)
 
         # Concatenate columns horizontally
-        synth = np.hstack((synth1, synth2))
+        synth = synth1 + synth2
+        synth[-2 * fs :, :] = 0.0
 
     elif mode == "melody":
         synth, fs = pyFDN.load_audio("synth_dry.wav")
@@ -96,10 +106,9 @@ def _(mo, np, pyFDN):
         samples = np.arange(len(synth))
         time = (samples / fs) * 1000 * 1000
 
-        _output = mo.vstack([mo.audio(synth, fs)])
-
-    _output
-    return fs, mode, synth, time
+    _audio_src = synth.T if synth.ndim == 2 else synth
+    mo.vstack([mo.audio(_audio_src, fs)])
+    return fs, synth
 
 
 @app.cell(hide_code=True)
@@ -111,9 +120,9 @@ def _(mo):
 
 
 @app.cell
-def _(la, mode, np, random_orthogonal):
+def _(la, np, random_orthogonal):
     N = 8
-    num_input = 1 if mode == "melody" else 2
+    num_input = 1
     num_output = 2
 
     input_gain = la.orth(np.random.randn(N, num_input))
@@ -181,13 +190,13 @@ def _(
             spread = 0
 
         elif matrix_type == "slow_variation":
-            modulation_frequency = 1  # hz
-            modulation_amplitude = 0.9
+            modulation_frequency = 1.0  # hz
+            modulation_amplitude = 3.0
             spread = 0.3
 
         elif matrix_type == "fast_variation":
             modulation_frequency = 10  # hz
-            modulation_amplitude = 0.1
+            modulation_amplitude = 1.1
             spread = 0.7
 
         tv_matrix = TimeVaryingMatrix(
@@ -216,21 +225,21 @@ def _(mo):
 
 
 @app.cell
-def _(matrix_types, plt, reverbed_synth, time):
-    plt.figure(figsize=(10, 6))
-    plt.title("Time-Varying FDN Output")
-    plt.grid(True, linestyle="--", alpha=0.6)
-
-    # Plot each matrix type with distinct styles
-    for it, name in enumerate(matrix_types):
-        plt.plot(time, reverbed_synth[name][:, 0] + it * 1.5, label=name, linewidth=1.5)
-
-    plt.legend(loc="upper right", title="Matrix Types")
-    plt.xlabel("Time [seconds]")
-    plt.ylabel("Amplitude")
-    plt.tight_layout()
-
-    plt.show()
+def _(fs, matrix_types, mo, pyFDN, reverbed_synth):
+    mo.vstack(
+        [
+            pyFDN.plot_spectrogram(
+                reverbed_synth[name][:, 0],
+                fs,
+                nperseg=2048 * 8,
+                noverlap=2048 * 1,
+                title=f"{name} — spectrogram",
+                colorscale="Magma",
+                height=350,
+            )
+            for name in matrix_types
+        ]
+    )
     return
 
 

--- a/examples/example_time_varying_fdn.py
+++ b/examples/example_time_varying_fdn.py
@@ -39,15 +39,15 @@ def _(mo):
 
 @app.cell
 def _():
+    import matplotlib.pyplot as plt
     import numpy as np
     import scipy.linalg as la
-    import matplotlib.pyplot as plt
-    import plotly.graph_objects as go
+
+    import pyFDN
     from pyFDN.auxiliary.acoustics import one_pole_absorption
     from pyFDN.dsp.time_varying_matrix import TimeVaryingMatrix
     from pyFDN.generate.random_orthogonal import random_orthogonal
     from pyFDN.process import process_fdn
-    import pyFDN
 
     return (
         TimeVaryingMatrix,
@@ -74,10 +74,10 @@ def _(mo, np, pyFDN):
     np.random.seed(1)
 
     # init source signal
-    mode = 'melody'
+    mode = "melody"
     _output = None
 
-    if mode == 'sine':
+    if mode == "sine":
         fs = 48000
         time = np.linspace(0, 4, 4 * fs)[:, None]
 
@@ -87,12 +87,12 @@ def _(mo, np, pyFDN):
         # Concatenate columns horizontally
         synth = np.hstack((synth1, synth2))
 
-    elif mode == 'melody':
+    elif mode == "melody":
         synth, fs = pyFDN.load_audio("synth_dry.wav")
         print(f"Loaded {len(synth)} samples at {fs} Hz ({len(synth) / fs:.2f} s)")
 
         samples = np.arange(len(synth))
-        time = ((samples / fs) * 1000 * 1000)
+        time = (samples / fs) * 1000 * 1000
 
         _output = mo.vstack([mo.audio(synth, fs)])
 
@@ -111,7 +111,7 @@ def _(mo):
 @app.cell
 def _(la, mode, np, random_orthogonal):
     N = 8
-    num_input = 1 if mode == 'melody' else 2
+    num_input = 1 if mode == "melody" else 2
     num_output = 2
 
     input_gain = la.orth(np.random.randn(N, num_input))
@@ -119,7 +119,7 @@ def _(la, mode, np, random_orthogonal):
     random_matrix = np.random.randn(num_output, N)
     output_gain = la.orth(random_matrix.T).T
 
-    direct = np.zeros((num_output,num_input))
+    direct = np.zeros((num_output, num_input))
     delays = np.random.randint(750, 2001, size=N)[None, :]
 
     feedback_matrix = random_orthogonal(N)
@@ -135,12 +135,15 @@ def _(mo):
 
 
 @app.cell
-def _(delays, fs, one_pole_absorption):
-    RT_DC = 4 # seconds
-    RT_NY = 1 # seconds
+def _(N, delays, fs, one_pole_absorption, pyFDN):
+    RT_DC = 4  # seconds
+    RT_NY = 1  # seconds
 
     coeffs = one_pole_absorption(RT_DC, RT_NY, delays, fs)
-    return (coeffs,)
+
+    # Constract the absorption
+    absorption = pyFDN.SOSFilterBank(coeffs, N)
+    return (absorption,)
 
 
 @app.cell(hide_code=True)
@@ -155,7 +158,7 @@ def _(mo):
 def _(
     N,
     TimeVaryingMatrix,
-    coeffs,
+    absorption,
     delays,
     direct,
     feedback_matrix,
@@ -165,22 +168,22 @@ def _(
     process_fdn,
     synth,
 ):
-    matrix_types = ['no_variation', 'slow_variation','fast_variation']
+    matrix_types = ["no_variation", "slow_variation", "fast_variation"]
 
     reverbed_synth = {}
 
     for matrix_type in matrix_types:
-        if matrix_type == 'no_variation':
+        if matrix_type == "no_variation":
             modulation_frequency = 0  # hz
             modulation_amplitude = 0.0
             spread = 0
 
-        elif matrix_type == 'slow_variation':
+        elif matrix_type == "slow_variation":
             modulation_frequency = 1  # hz
             modulation_amplitude = 0.9
             spread = 0.3
 
-        elif matrix_type == 'fast_variation':
+        elif matrix_type == "fast_variation":
             modulation_frequency = 10  # hz
             modulation_amplitude = 0.1
             spread = 0.7
@@ -196,7 +199,7 @@ def _(
             input_gain,
             output_gain,
             direct,
-            absorption_filters=coeffs,
+            absorption=absorption,
             extra_matrix=tv_matrix,
         )
     return matrix_types, reverbed_synth
@@ -214,18 +217,13 @@ def _(mo):
 def _(matrix_types, plt, reverbed_synth, time):
     plt.figure(figsize=(10, 6))
     plt.title("Time-Varying FDN Output")
-    plt.grid(True, linestyle='--', alpha=0.6) 
+    plt.grid(True, linestyle="--", alpha=0.6)
 
     # Plot each matrix type with distinct styles
     for it, name in enumerate(matrix_types):
-        plt.plot(
-            time, 
-            reverbed_synth[name][:, 0] + it * 1.5,
-            label=name,
-            linewidth=1.5
-        )
+        plt.plot(time, reverbed_synth[name][:, 0] + it * 1.5, label=name, linewidth=1.5)
 
-    plt.legend(loc='upper right', title="Matrix Types")
+    plt.legend(loc="upper right", title="Matrix Types")
     plt.xlabel("Time [seconds]")
     plt.ylabel("Amplitude")
     plt.tight_layout()
@@ -244,13 +242,14 @@ def _(mo):
 
 @app.cell
 def _(fs, matrix_types, mo, reverbed_synth):
-    mo.vstack([
-        mo.vstack([
-            mo.md(f"**{name}**"),
-            mo.audio(src=reverbed_synth[name].T, rate=fs)
-        ])
-        for name in matrix_types
-    ])
+    mo.vstack(
+        [
+            mo.vstack(
+                [mo.md(f"**{name}**"), mo.audio(src=reverbed_synth[name].T, rate=fs)]
+            )
+            for name in matrix_types
+        ]
+    )
     return
 
 

--- a/examples/example_time_varying_fdn.py
+++ b/examples/example_time_varying_fdn.py
@@ -1,0 +1,258 @@
+import marimo
+
+__generated_with = "0.23.9"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Time Varying FDN
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Example for time-varying matrices.<br/>
+    Process a musical sound with a time-varying FDN reverberation. Different
+    options include slow and fast time-variation.
+
+
+    Reference: *Schlecht and Habets 2015 : "Practical Considerations of Time-Varying
+    Feedback Delay Networks"* <br/>
+    Reference: *Schlecht and Habets 2015 : "Time-varying feedback matrices in feedback delay networks
+    and their application in artificial reverberation"*
+
+    Original MATLAB: Sebastian J. Schlecht, Saturday, 28 December 2019
+    """)
+    return
+
+
+@app.cell
+def _():
+    import numpy as np
+    import scipy.linalg as la
+    import matplotlib.pyplot as plt
+    import plotly.graph_objects as go
+    from pyFDN.auxiliary.acoustics import one_pole_absorption
+    from pyFDN.dsp.time_varying_matrix import TimeVaryingMatrix
+    from pyFDN.generate.random_orthogonal import random_orthogonal
+    from pyFDN.process import process_fdn
+    import pyFDN
+
+    return (
+        TimeVaryingMatrix,
+        la,
+        np,
+        one_pole_absorption,
+        plt,
+        process_fdn,
+        pyFDN,
+        random_orthogonal,
+    )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Object Initialization & Audio Loading
+    """)
+    return
+
+
+@app.cell
+def _(mo, np, pyFDN):
+    np.random.seed(1)
+
+    # init source signal
+    mode = 'melody'
+    _output = None
+
+    if mode == 'sine':
+        fs = 48000
+        time = np.linspace(0, 4, 4 * fs)[:, None]
+
+        synth1 = 0.5 * np.sin(time * 440 * 2 * np.pi)
+        synth2 = 0.5 * np.sin(time * 660 * 2 * np.pi)
+
+        # Concatenate columns horizontally
+        synth = np.hstack((synth1, synth2))
+
+    elif mode == 'melody':
+        synth, fs = pyFDN.load_audio("synth_dry.wav")
+        print(f"Loaded {len(synth)} samples at {fs} Hz ({len(synth) / fs:.2f} s)")
+
+        samples = np.arange(len(synth))
+        time = ((samples / fs) * 1000 * 1000)
+
+        _output = mo.vstack([mo.audio(synth, fs)])
+
+    _output
+    return fs, mode, synth, time
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Define FDN: Signal Dimensionality & Formatting
+    """)
+    return
+
+
+@app.cell
+def _(la, mode, np, random_orthogonal):
+    N = 8
+    num_input = 1 if mode == 'melody' else 2
+    num_output = 2
+
+    input_gain = la.orth(np.random.randn(N, num_input))
+
+    random_matrix = np.random.randn(num_output, N)
+    output_gain = la.orth(random_matrix.T).T
+
+    direct = np.zeros((num_output,num_input))
+    delays = np.random.randint(750, 2001, size=N)[None, :]
+
+    feedback_matrix = random_orthogonal(N)
+    return N, delays, direct, feedback_matrix, input_gain, output_gain
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Generate Absorption Ailter
+    """)
+    return
+
+
+@app.cell
+def _(delays, fs, one_pole_absorption):
+    RT_DC = 4 # seconds
+    RT_NY = 1 # seconds
+
+    coeffs = one_pole_absorption(RT_DC, RT_NY, delays, fs)
+    return (coeffs,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Time Varying Matrix Generation & Reverberation Processing Across Matrix Variations
+    """)
+    return
+
+
+@app.cell
+def _(
+    N,
+    TimeVaryingMatrix,
+    coeffs,
+    delays,
+    direct,
+    feedback_matrix,
+    fs,
+    input_gain,
+    output_gain,
+    process_fdn,
+    synth,
+):
+    matrix_types = ['no_variation', 'slow_variation','fast_variation']
+
+    reverbed_synth = {}
+
+    for matrix_type in matrix_types:
+        if matrix_type == 'no_variation':
+            modulation_frequency = 0  # hz
+            modulation_amplitude = 0.0
+            spread = 0
+
+        elif matrix_type == 'slow_variation':
+            modulation_frequency = 1  # hz
+            modulation_amplitude = 0.9
+            spread = 0.3
+
+        elif matrix_type == 'fast_variation':
+            modulation_frequency = 10  # hz
+            modulation_amplitude = 0.1
+            spread = 0.7
+
+        tv_matrix = TimeVaryingMatrix(
+            N, modulation_frequency, modulation_amplitude, fs, spread
+        )
+
+        reverbed_synth[matrix_type] = process_fdn(
+            synth,
+            delays,
+            feedback_matrix,
+            input_gain,
+            output_gain,
+            direct,
+            absorption_filters=coeffs,
+            extra_matrix=tv_matrix,
+        )
+    return matrix_types, reverbed_synth
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Output Visualization
+    """)
+    return
+
+
+@app.cell
+def _(matrix_types, plt, reverbed_synth, time):
+    plt.figure(figsize=(10, 6))
+    plt.title("Time-Varying FDN Output")
+    plt.grid(True, linestyle='--', alpha=0.6) 
+
+    # Plot each matrix type with distinct styles
+    for it, name in enumerate(matrix_types):
+        plt.plot(
+            time, 
+            reverbed_synth[name][:, 0] + it * 1.5,
+            label=name,
+            linewidth=1.5
+        )
+
+    plt.legend(loc='upper right', title="Matrix Types")
+    plt.xlabel("Time [seconds]")
+    plt.ylabel("Amplitude")
+    plt.tight_layout()
+
+    plt.show()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Audio Playback
+    """)
+    return
+
+
+@app.cell
+def _(fs, matrix_types, mo, reverbed_synth):
+    mo.vstack([
+        mo.vstack([
+            mo.md(f"**{name}**"),
+            mo.audio(src=reverbed_synth[name].T, rate=fs)
+        ])
+        for name in matrix_types
+    ])
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/example_time_varying_fdn.py
+++ b/examples/example_time_varying_fdn.py
@@ -1,3 +1,5 @@
+# gallery_category: FDN Design & Analysis
+
 import marimo
 
 __generated_with = "0.23.9"

--- a/src/pyFDN/dsp/time_varying_matrix.py
+++ b/src/pyFDN/dsp/time_varying_matrix.py
@@ -11,8 +11,6 @@ Python translation: Alma Hova, 2026
 
 import numpy as np
 
-from pyFDN.auxiliary.tiny_rotation_matrix import rotation_matrix_from_angles
-
 
 class TimeVaryingMatrix:
     """
@@ -106,8 +104,10 @@ class TimeVaryingMatrix:
         """
         Applies a time-varying orthogonal transformation to the input signal.
 
-        For each time step, a matrix Q(n) is constructed from the current
-        modulation state and applied to the signal.
+        Each adjacent channel pair is rotated by a sinusoidally modulated
+        angle. The operation is equivalent to constructing the block-diagonal
+        rotation matrix from ``rotation_matrix_from_angles`` at every sample,
+        but applies the 2-D rotations directly to the whole input block.
 
         Parameters
         ----------
@@ -120,35 +120,25 @@ class TimeVaryingMatrix:
         out : ndarray
             Output signal of the same shape as `x_in`.
         """
+        x = np.asarray(x_in)
+        if x.ndim != 2 or x.shape[1] != self.N:
+            raise ValueError(f"x_in must have shape (length, {self.N})")
 
-        # Get the number of audio samples in the incoming block
-        length = x_in.shape[0]
+        length = x.shape[0]
+        sample_indices = self.sample_index + np.arange(length)
+        time = sample_indices[:, np.newaxis] / self.fs
+        angles = self.angle_amplitude * np.sin(
+            2 * np.pi * self.frequency * time + self.phase
+        )
+        cos = np.cos(angles)
+        sin = np.sin(angles)
 
-        # Output array matching the size of the input
-        out = np.empty_like(x_in)
+        x_pairs = x.reshape(length, self.num_pairs, 2)
+        out = np.empty(x.shape, dtype=np.result_type(x, self.angle_amplitude, float))
+        out_pairs = out.reshape(length, self.num_pairs, 2)
+        out_pairs[..., 0] = cos * x_pairs[..., 0] - sin * x_pairs[..., 1]
+        out_pairs[..., 1] = sin * x_pairs[..., 0] + cos * x_pairs[..., 1]
 
-        # Loop through every single audio sample instance in the block
-        for n in range(length):
-            # Calculate the absolute time 't' in seconds from the start of processing
-            t = (self.sample_index + n) / self.fs
-
-            # Compute the rotation angle for each 2D plane at time instance 't'
-            # using independent sinusoidal oscillators
-            angles = self.angle_amplitude * np.sin(
-                2 * np.pi * self.frequency * t + self.phase
-            )
-
-            # generate the combined N x N real orthogonal feedback matrix Q(n) for this sample
-            Q = rotation_matrix_from_angles(
-                angles,
-                n=self.N,
-            )
-
-            # Matrix-vector multiplication: Apply the orthogonal transformation matrix Q
-            # to the multi-channel input sample vector at index [n]
-            out[n] = Q @ x_in[n]
-
-        # Accumulate the total processed sample length
         self.sample_index += length
 
         return out

--- a/src/pyFDN/dsp/time_varying_matrix.py
+++ b/src/pyFDN/dsp/time_varying_matrix.py
@@ -1,8 +1,8 @@
 """
 Time Varying matrix generator for FDN feedback matrices.
 
-This module provides a Python implementation of a time-varying matrix generator 
-for Feedback Delay Network (FDN) feedback matrices. 
+This module provides a Python implementation of a time-varying matrix generator
+for Feedback Delay Network (FDN) feedback matrices.
 Translation of the MATLAB implementation `timeVaryingMatrix.m` from fdnToolbox.
 
 Original MATLAB code: (c) Sebastian Jiro Schlecht, 2019
@@ -10,6 +10,7 @@ Python translation: Alma Hova, 2026
 """
 
 import numpy as np
+
 from pyFDN.auxiliary.tiny_rotation_matrix import rotation_matrix_from_angles
 
 
@@ -17,8 +18,8 @@ class TimeVaryingMatrix:
     """
     Time Varying Matrix for Feedback Delay Networks (FDNs).
 
-    This class generates a time-varying matrix for FDN feedback matrices. The 
-    matrix varies over time based on sinusoidal modulation, with parameters 
+    This class generates a time-varying matrix for FDN feedback matrices. The
+    matrix varies over time based on sinusoidal modulation, with parameters
     controlling the speed, amplitude, and randomness of the variation.
 
     Parameters
@@ -41,11 +42,11 @@ class TimeVaryingMatrix:
         cycles_per_second: float,
         amplitude: float,
         fs: float,
-            spread: float
+        spread: float,
     ) -> None:
         """
         Initialize the TimeVaryingMatrix object.
-        
+
         Attributes
         ----------
         N : int
@@ -78,7 +79,7 @@ class TimeVaryingMatrix:
 
         self.N = N
         self.cycles_per_second = cycles_per_second
-        self.amplitude = amplitude                      
+        self.amplitude = amplitude
         self.fs = fs
         self.spread = spread
 
@@ -90,21 +91,18 @@ class TimeVaryingMatrix:
 
         # Calculate a unique modulation frequency for each pair using the spread factor
         self.frequency = self.cycles_per_second * (
-            1 
-            + self.spread * (2 * np.random.rand(self.num_pairs) - 1)
+            1 + self.spread * (2 * np.random.rand(self.num_pairs) - 1)
         )
 
         # Modulation Amplitude
         self.angle_amplitude = self.amplitude * (
-            1
-            + self.spread * (2 * np.random.rand(self.num_pairs) - 1)
+            1 + self.spread * (2 * np.random.rand(self.num_pairs) - 1)
         )
-        
+
         # Global time tracker index, initialized to 0
         self.sample_index = 0
 
-
-    def filter(self, x_in: np.ndarray) -> np.ndarray: 
+    def filter(self, x_in: np.ndarray) -> np.ndarray:
         """
         Applies a time-varying orthogonal transformation to the input signal.
 
@@ -114,7 +112,7 @@ class TimeVaryingMatrix:
         Parameters
         ----------
         x_in : ndarray
-            Input signal of shape (length, N), where `length` is the number of 
+            Input signal of shape (length, N), where `length` is the number of
             samples and `N` is the number of channels.
 
         Returns
@@ -131,18 +129,13 @@ class TimeVaryingMatrix:
 
         # Loop through every single audio sample instance in the block
         for n in range(length):
-
             # Calculate the absolute time 't' in seconds from the start of processing
             t = (self.sample_index + n) / self.fs
 
-            # Compute the rotation angle for each 2D plane at time instance 't' 
+            # Compute the rotation angle for each 2D plane at time instance 't'
             # using independent sinusoidal oscillators
-            angles = (
-                self.angle_amplitude
-                * np.sin(
-                    2 * np.pi * self.frequency * t
-                    + self.phase
-                )
+            angles = self.angle_amplitude * np.sin(
+                2 * np.pi * self.frequency * t + self.phase
             )
 
             # generate the combined N x N real orthogonal feedback matrix Q(n) for this sample
@@ -150,8 +143,8 @@ class TimeVaryingMatrix:
                 angles,
                 n=self.N,
             )
-            
-            # Matrix-vector multiplication: Apply the orthogonal transformation matrix Q 
+
+            # Matrix-vector multiplication: Apply the orthogonal transformation matrix Q
             # to the multi-channel input sample vector at index [n]
             out[n] = Q @ x_in[n]
 

--- a/src/pyFDN/dsp/time_varying_matrix.py
+++ b/src/pyFDN/dsp/time_varying_matrix.py
@@ -1,0 +1,161 @@
+"""
+Time Varying matrix generator for FDN feedback matrices.
+
+This module provides a Python implementation of a time-varying matrix generator 
+for Feedback Delay Network (FDN) feedback matrices. 
+Translation of the MATLAB implementation `timeVaryingMatrix.m` from fdnToolbox.
+
+Original MATLAB code: (c) Sebastian Jiro Schlecht, 2019
+Python translation: Alma Hova, 2026
+"""
+
+import numpy as np
+from pyFDN.auxiliary.tiny_rotation_matrix import rotation_matrix_from_angles
+
+
+class TimeVaryingMatrix:
+    """
+    Time Varying Matrix for Feedback Delay Networks (FDNs).
+
+    This class generates a time-varying matrix for FDN feedback matrices. The 
+    matrix varies over time based on sinusoidal modulation, with parameters 
+    controlling the speed, amplitude, and randomness of the variation.
+
+    Parameters
+    ----------
+    N : int
+        Number of channels (size of the matrix is N x N). Must be a positive even integer.
+    cycles_per_second : float
+        Frequency of the time variation in Hz (controls oscillation speed).
+    amplitude : float
+        Maximum angle deflection in radians (strength of modulation).
+    fs : float
+        Sampling rate in Hz.
+    spread : float
+        Randomness factor (controls how differently each eigenmode behaves).
+    """
+
+    def __init__(
+        self,
+        N: int,
+        cycles_per_second: float,
+        amplitude: float,
+        fs: float,
+            spread: float
+    ) -> None:
+        """
+        Initialize the TimeVaryingMatrix object.
+        
+        Attributes
+        ----------
+        N : int
+            Number of channels.
+        cycles_per_second : float
+            Frequency of the time variation in Hz.
+        amplitude : float
+            Maximum angle deflection in radians.
+        fs : float
+            Sampling rate in Hz.
+        spread : float
+            Randomness factor.
+        num_pairs : int
+            Number of eigenmode pairs (N // 2).
+        phase : ndarray
+            Random initial phases for each eigenmode pair.
+        frequency : ndarray
+            Frequencies of oscillation for each eigenmode pair.
+        angle_amplitude : ndarray
+            Amplitudes of oscillation for each eigenmode pair.
+        sample_index : int
+            Current sample index for time tracking.
+        """
+        # Enforce N to be a positive, even integer.
+        N = int(N)
+        if N <= 0:
+            raise ValueError("N must be a positive integer")
+        if N % 2 != 0:
+            raise ValueError("N must be even")
+
+        self.N = N
+        self.cycles_per_second = cycles_per_second
+        self.amplitude = amplitude                      
+        self.fs = fs
+        self.spread = spread
+
+        # Calculate the number of independent 2D rotation planes (conjugate eigenvalue pairs)
+        self.num_pairs = N // 2
+
+        # Assign a random initial phase between 0 and 2*pi for each 2D plane
+        self.phase = 2 * np.pi * np.random.rand(self.num_pairs)
+
+        # Calculate a unique modulation frequency for each pair using the spread factor
+        self.frequency = self.cycles_per_second * (
+            1 
+            + self.spread * (2 * np.random.rand(self.num_pairs) - 1)
+        )
+
+        # Modulation Amplitude
+        self.angle_amplitude = self.amplitude * (
+            1
+            + self.spread * (2 * np.random.rand(self.num_pairs) - 1)
+        )
+        
+        # Global time tracker index, initialized to 0
+        self.sample_index = 0
+
+
+    def filter(self, x_in: np.ndarray) -> np.ndarray: 
+        """
+        Applies a time-varying orthogonal transformation to the input signal.
+
+        For each time step, a matrix Q(n) is constructed from the current
+        modulation state and applied to the signal.
+
+        Parameters
+        ----------
+        x_in : ndarray
+            Input signal of shape (length, N), where `length` is the number of 
+            samples and `N` is the number of channels.
+
+        Returns
+        -------
+        out : ndarray
+            Output signal of the same shape as `x_in`.
+        """
+
+        # Get the number of audio samples in the incoming block
+        length = x_in.shape[0]
+
+        # Output array matching the size of the input
+        out = np.empty_like(x_in)
+
+        # Loop through every single audio sample instance in the block
+        for n in range(length):
+
+            # Calculate the absolute time 't' in seconds from the start of processing
+            t = (self.sample_index + n) / self.fs
+
+            # Compute the rotation angle for each 2D plane at time instance 't' 
+            # using independent sinusoidal oscillators
+            angles = (
+                self.angle_amplitude
+                * np.sin(
+                    2 * np.pi * self.frequency * t
+                    + self.phase
+                )
+            )
+
+            # generate the combined N x N real orthogonal feedback matrix Q(n) for this sample
+            Q = rotation_matrix_from_angles(
+                angles,
+                n=self.N,
+            )
+            
+            # Matrix-vector multiplication: Apply the orthogonal transformation matrix Q 
+            # to the multi-channel input sample vector at index [n]
+            out[n] = Q @ x_in[n]
+
+        # Accumulate the total processed sample length
+        self.sample_index += length
+
+        return out

--- a/src/pyFDN/process.py
+++ b/src/pyFDN/process.py
@@ -20,7 +20,7 @@ def process_fdn(
     C: ArrayLike,
     D: ArrayLike,
     *,
-    absorption_filters: ArrayLike | None = None,
+    absorption: SOSFilterBank | None = None,
     extra_matrix: Any | None = None,
 ) -> np.ndarray:
     """Simulate the feedback delay network using block processing.
@@ -40,7 +40,7 @@ def process_fdn(
         z^{-1} convention.
     B, C, D : array
         Static input, output, and direct gains.
-    absorption_filters : array, optional
+    absorption : object, optional
         Per-delay-line SOS filters; see :class:`pyFDN.dsp.SOSFilterBank` for
         accepted shapes. Applied to the delay outputs inside the loop.
     extra_matrix : object, optional
@@ -74,11 +74,6 @@ def process_fdn(
         feedback_filter = None
     else:
         raise ValueError("A must be a 2-D (static) or 3-D (FIR) matrix")
-
-    if absorption_filters is not None:
-        absorption: SOSFilterBank | None = SOSFilterBank(absorption_filters, n)
-    else:
-        absorption = None
 
     max_block_size = min(int(2**12), int(np.min(delays_arr)))
     delay_bank = FeedbackDelay(delays_arr, max_block_size)

--- a/src/pyFDN/process.py
+++ b/src/pyFDN/process.py
@@ -66,7 +66,6 @@ def process_fdn(
     delays_arr = np.asarray(delays, dtype=int).reshape(-1)
     if np.any(delays_arr <= 0):
         raise ValueError("Delays must be positive integers")
-    n = delays_arr.size
 
     if A_mat.ndim == 3:
         feedback_filter: FIRMatrixFilter | None = FIRMatrixFilter(A_mat)

--- a/src/pyFDN/translate/flamo_to_pr.py
+++ b/src/pyFDN/translate/flamo_to_pr.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import warnings
 from collections import OrderedDict
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -15,7 +16,6 @@ import numpy as np
 import torch
 
 from pyFDN.auxiliary.poles import reduce_conjugate_pairs
-
 
 # ───────────────────────────────────────────────────────────────────────────
 # Small infrastructure helpers
@@ -83,10 +83,10 @@ def _rcond_torch(mat: torch.Tensor) -> float:
 # ───────────────────────────────────────────────────────────────────────────
 
 
-def _make_log_det_derivative_w(recursion: Any):
+def _make_log_det_derivative_w(recursion: Any) -> Callable[[complex], torch.Tensor]:
     """Build (d/dw) log det P(w) once using grad; uses recursion.probe_recursion_w(w)."""
 
-    def d_log_det_w(w):
+    def d_log_det_w(w: complex) -> torch.Tensor:
         w_var = _as_torch_complex_scalar(w, model=recursion)
         w_var = w_var.detach().clone().requires_grad_(True)
         P_w = recursion.probe_recursion_w(w_var)
@@ -97,14 +97,18 @@ def _make_log_det_derivative_w(recursion: Any):
     return d_log_det_w
 
 
-def _make_P_and_dP_dz(recursion: Any):
+def _make_P_and_dP_dz(
+    recursion: Any,
+) -> Callable[[complex], tuple[torch.Tensor, torch.Tensor]]:
     """Build (P(z), dP/dz(z)) once using JVP; uses recursion.probe_recursion(z)."""
 
-    def get_P_and_dP_dz(z):
+    def get_P_and_dP_dz(z: complex) -> tuple[torch.Tensor, torch.Tensor]:
         z_var = _as_torch_complex_scalar(z, model=recursion)
         dz = torch.ones_like(z_var)
         P, dP_dz = torch.autograd.functional.jvp(
-            recursion.probe_recursion, (z_var,), (dz,)
+            recursion.probe_recursion,
+            (z_var,),
+            (dz,),  # type: ignore[no-untyped-call]
         )
         return P.detach(), dP_dz.detach()
 
@@ -166,7 +170,7 @@ def _series_slice_to_subgraph(series: Any, start: int, end: int) -> Any | None:
     if n == 1:
         return series[start]
     try:
-        from flamo.processor import system as flamo_system  # type: ignore
+        from flamo.processor import system as flamo_system
     except Exception as exc:
         raise RuntimeError(
             "FLAMO system.Series is required for multi-module subgraphs."
@@ -238,7 +242,7 @@ def _delays_from_recursion(recursion_module: Any) -> np.ndarray:
     return np.asarray(np.round(out), dtype=int)
 
 
-def _iter_leaf_modules(node: Any):
+def _iter_leaf_modules(node: Any) -> Iterator[Any]:
     """Yield the leaf modules of a FLAMO subgraph, descending into Series-like
     containers. Non-iterable modules (Gain, Delay, SOSFilter, …) are leaves."""
     try:
@@ -322,7 +326,7 @@ class _FDNLoopFlamo:
 
     recursion: Any
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         rec = self.recursion
         z0 = _as_torch_complex_scalar(1.0 + 0j, model=rec)
         p0 = rec.probe_recursion(z0)
@@ -811,9 +815,7 @@ def flamo_to_pr(
             raise ValueError(f"num_poles must be a positive integer, got {num_poles}.")
         n_poles = int(num_poles)
         if verbose:
-            print(
-                f"Overriding detected pole count: num_poles={n_poles}"
-            )
+            print(f"Overriding detected pole count: num_poles={n_poles}")
 
     # Seed equi-spaced on the unit circle in the w = 1/z domain. With IIR filters
     # in the loop the poles spread inward (off the unit circle) and plain
@@ -877,9 +879,7 @@ def flamo_to_pr(
         sym_tol = max(float(quality_threshold) * 1000.0, 1e-9)
         poles_np = _conjugate_symmetrize(poles_np, tol=sym_tol)
 
-    poles, is_conjugate, non_paired = reduce_conjugate_pairs(
-        poles_np, verbose=verbose
-    )
+    poles, is_conjugate, non_paired = reduce_conjugate_pairs(poles_np, verbose=verbose)
     meta_data["nonPairedPoles"] = non_paired
 
     residues, direct, undriven, eigenvectors = _dss_to_res_flamo(

--- a/tests/test_dss_to_pr.py
+++ b/tests/test_dss_to_pr.py
@@ -43,9 +43,7 @@ def test_dss_to_pr_eig_mode_reconstructs_ir():
     c = np.eye(1, delays.size)
     d = np.zeros((1, 1))
 
-    residues, poles, direct, is_pair, _ = dss_to_pr(
-        delays, a, b, c, d, mode="eig"
-    )
+    residues, poles, direct, is_pair, _ = dss_to_pr(delays, a, b, c, d, mode="eig")
 
     ir_len = 512
     ir_time = dss_to_impz(ir_len, delays, a, b, c, d)[:, 0, 0]
@@ -62,7 +60,12 @@ def test_dss_to_pr_roots_mode_reconstructs_ir():
     d = np.zeros((1, 1))
 
     residues, poles, direct, is_conj, _ = dss_to_pr(
-        delays, a, b, c, d, mode="roots",
+        delays,
+        a,
+        b,
+        c,
+        d,
+        mode="roots",
     )
 
     ir_len = 512
@@ -83,9 +86,7 @@ def test_dss_to_pr_roots_mode_meta_shape():
     c = np.eye(1, delays.size)
     d = np.zeros((1, 1))
 
-    residues, poles, direct, is_pair, meta = dss_to_pr(
-        delays, a, b, c, d, mode="roots"
-    )
+    residues, poles, direct, is_pair, meta = dss_to_pr(delays, a, b, c, d, mode="roots")
 
     assert residues.ndim == 3
     assert poles.ndim == 1
@@ -114,7 +115,15 @@ def test_dss_to_pr_eai_matches_roots():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         res_new, pol_new, direct_new, pair_new, _ = dss_to_pr(
-            delays, a, b, c, d, mode="eai", Fs=1.0, nfft=1024, verbose=False,
+            delays,
+            a,
+            b,
+            c,
+            d,
+            mode="eai",
+            Fs=1.0,
+            nfft=1024,
+            verbose=False,
         )
 
     # Same pole-set cardinality (after conjugate-pair reduction).
@@ -150,7 +159,12 @@ def test_dss_to_pr_residue_lstsq_match():
     ir_len = 4 * int(np.sum(delays))
     ir_time = dss_to_impz(ir_len, delays, a, b, c, d)[:, 0, 0]
     residues, poles, direct, is_conj, _ = dss_to_pr(
-        delays, a, b, c, d, mode="eig",
+        delays,
+        a,
+        b,
+        c,
+        d,
+        mode="eig",
     )
     ir_modal = pr_to_impz(residues, poles, direct, is_conj, ir_len)[:, 0, 0]
     residues_from_ir, _, _ = impz_to_res(ir_time, poles, is_conj)

--- a/tests/test_flamo_to_pr.py
+++ b/tests/test_flamo_to_pr.py
@@ -31,8 +31,15 @@ def test_flamo_to_pr_matches_dss_to_pr_eai():
     # Build the model in float64 so flamo_to_pr matches dss_to_pr's
     # (now-default) machine-precision behavior.
     model = dss_to_flamo(
-        A=a, B=b, C=c, D=d, m=delays, Fs=1.0, nfft=1024,
-        shell=False, dtype=torch.float64,
+        A=a,
+        B=b,
+        C=c,
+        D=d,
+        m=delays,
+        Fs=1.0,
+        nfft=1024,
+        shell=False,
+        dtype=torch.float64,
     )
 
     with warnings.catch_warnings():
@@ -41,7 +48,15 @@ def test_flamo_to_pr_matches_dss_to_pr_eai():
             model, verbose=False
         )
         res_wrap, pol_wrap, direct_wrap, pair_wrap, _ = dss_to_pr(
-            delays, a, b, c, d, mode="eai", Fs=1.0, nfft=1024, verbose=False,
+            delays,
+            a,
+            b,
+            c,
+            d,
+            mode="eai",
+            Fs=1.0,
+            nfft=1024,
+            verbose=False,
         )
 
     assert pol_model.size == pol_wrap.size
@@ -77,20 +92,30 @@ def test_flamo_to_pr_biquad_in_loop_reconstructs_ir():
 
     # Same genuine biquad lowpass (a2 != 0) on every delay line, as (1, 6, N).
     bq_b, bq_a = butter(2, 0.4)  # [b0, b1, b2], [a0, a1, a2]
-    sos_loop = np.tile(
-        np.concatenate([bq_b, bq_a])[:, None], (1, n)
-    )[np.newaxis, :, :]
+    sos_loop = np.tile(np.concatenate([bq_b, bq_a])[:, None], (1, n))[np.newaxis, :, :]
 
     model = dss_to_flamo(
-        A=a, B=b, C=c, D=d, m=delays, Fs=Fs, nfft=nfft,
-        shell=True, sos_filter=sos_loop, dtype=torch.float64,
+        A=a,
+        B=b,
+        C=c,
+        D=d,
+        m=delays,
+        Fs=Fs,
+        nfft=nfft,
+        shell=True,
+        sos_filter=sos_loop,
+        dtype=torch.float64,
     )
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         residues, poles, direct, is_pair, _ = flamo_to_pr(
-            model, reject_unstable_poles=True, maximum_iterations=300,
-            quality_threshold=1e-10, refinement_tol=1e-12, verbose=False,
+            model,
+            reject_unstable_poles=True,
+            maximum_iterations=300,
+            quality_threshold=1e-10,
+            refinement_tol=1e-12,
+            verbose=False,
         )
 
     # Pole count includes the biquad's 2 poles per line (a2 != 0), not just the

--- a/tests/test_process_extensions.py
+++ b/tests/test_process_extensions.py
@@ -150,10 +150,13 @@ def test_process_fdn_absorption_matches_flamo() -> None:
     # short RTs so the IR decays well within nfft (FLAMO is circular)
     sos = pyFDN.first_order_absorption(0.15, 0.05, delays, fs)  # (1, 6, N)
 
+    # constract the SOSFilter
+    absorption = pyFDN.SOSFilterBank(sos=sos, num_channels=n)
+
     ir_len = 4096
     impulse = np.zeros(ir_len)
     impulse[0] = 1.0
-    ir_td = pyFDN.process_fdn(impulse, delays, A, B, C, D, absorption_filters=sos)
+    ir_td = pyFDN.process_fdn(impulse, delays, A, B, C, D, absorption=absorption)
 
     model = pyFDN.dss_to_flamo(
         A,

--- a/tests/test_time_varying_matrix.py
+++ b/tests/test_time_varying_matrix.py
@@ -1,0 +1,70 @@
+"""Tests for time-varying feedback matrix processing."""
+
+import numpy as np
+import pytest
+
+from pyFDN.dsp.time_varying_matrix import TimeVaryingMatrix
+
+
+def _make_time_varying_matrix() -> TimeVaryingMatrix:
+    tvm = TimeVaryingMatrix(
+        N=4,
+        cycles_per_second=2.0,
+        amplitude=0.5,
+        fs=48000.0,
+        spread=0.0,
+    )
+    tvm.phase = np.array([0.25, 1.25])
+    tvm.frequency = np.array([2.0, 3.0])
+    tvm.angle_amplitude = np.array([0.5, 0.25])
+    tvm.sample_index = 0
+    return tvm
+
+
+def _explicit_pairwise_rotation(tvm: TimeVaryingMatrix, x: np.ndarray) -> np.ndarray:
+    length = x.shape[0]
+    sample_indices = tvm.sample_index + np.arange(length)
+    time = sample_indices[:, np.newaxis] / tvm.fs
+    angles = tvm.angle_amplitude * np.sin(2 * np.pi * tvm.frequency * time + tvm.phase)
+    cos = np.cos(angles)
+    sin = np.sin(angles)
+
+    x_pairs = x.reshape(length, tvm.num_pairs, 2)
+    out = np.empty_like(x)
+    out_pairs = out.reshape(length, tvm.num_pairs, 2)
+    out_pairs[..., 0] = cos * x_pairs[..., 0] - sin * x_pairs[..., 1]
+    out_pairs[..., 1] = sin * x_pairs[..., 0] + cos * x_pairs[..., 1]
+    return out
+
+
+def test_time_varying_matrix_filter_matches_pairwise_rotations():
+    tvm = _make_time_varying_matrix()
+    x = np.random.default_rng(0).standard_normal((32, 4))
+
+    expected = _explicit_pairwise_rotation(tvm, x)
+    out = tvm.filter(x)
+
+    np.testing.assert_allclose(out, expected)
+    assert tvm.sample_index == x.shape[0]
+
+
+def test_time_varying_matrix_filter_keeps_state_across_blocks():
+    x = np.random.default_rng(1).standard_normal((50, 4))
+    single_block = _make_time_varying_matrix()
+    split_block = _make_time_varying_matrix()
+
+    expected = single_block.filter(x)
+    out = np.vstack([split_block.filter(x[:17]), split_block.filter(x[17:])])
+
+    np.testing.assert_allclose(out, expected)
+    assert split_block.sample_index == x.shape[0]
+
+
+def test_time_varying_matrix_filter_rejects_wrong_shape():
+    tvm = _make_time_varying_matrix()
+
+    with pytest.raises(ValueError, match="shape"):
+        tvm.filter(np.zeros(4))
+
+    with pytest.raises(ValueError, match="shape"):
+        tvm.filter(np.zeros((8, 3)))


### PR DESCRIPTION
## Summary
This PR deals with translation of the time-varying matrix and its corresponding example from MATLAB codebase to Python. 
Additionally, it refactors the process_fdn API to pass full DSP objects rather than raw parameters, standardizing how absorption and time-varying matrices are handled.

I am opening this as a **Draft PR** to get initial feedback on the API architecture changes before finalizing.

## Changes
1. MATLAB to Python Translation
- `src/pyFDN/dsp/time_varying_matrix.py` is the python class of `timeVaryingMatrix.m`
- `examples/example_time_varying_fdn.py` is the corresponding python example, replacing `example_timeVaryingFDN.m`

2. API Refactoring & Standardization
- Refactored `pyFDN.process_fdn` to accept full DSP objects for both `TVmatrix` and `absorption filters`, rather than getting their raw parameters and construct them in `process_fdn`.
- Updated all relevant examples and test accordingly.

**please pay close attention to the process_fdn changes. Moving toward passing full DSP objects for both absorption and matrices is acceptable, or do we prefer the previous parameter-passing approach?**

## Ideas for future improvement
Couple of ideas for follow-up task:
1. Example Plotting: Right now, the example runs either the 'melody' or 'sine' signal per execution. It might be more informative to run and plot both in separate plots within the same run to clearly contrast the differences.
2. Visualization Modernization: The current example uses basic Matplotlib (plt). It might be better to switch this to an interactive framework like Plotly.

## Testing
- [x] `pytest` passes locally
- [ ] New tests added for new functionality
- [ ] Coverage not decreased (`pytest --cov=pyFDN`)

## Checklist
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Docstrings updated for any changed public API
- [ ] `HISTORY.rst` updated if this is a user-facing change