### PR TITLE
Add time-domain IR render and utility functions

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -195,7 +195,7 @@ State-Space Translators
 
    pyFDN.dss_to_ss
    pyFDN.dss_to_impz
-   pyFDN.build_impulse_response
+   pyFDN.build_to_impz
    pyFDN.dss_to_tf
    pyFDN.dss_to_pr
    pyFDN.dss_to_flamo

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -172,6 +172,7 @@ General Utilities
    pyFDN.lin_to_db
    pyFDN.sq_to_db
    pyFDN.ensure_3d
+   pyFDN.fade_out
    pyFDN.hertz_to_unit
    pyFDN.hertz_to_rad
    pyFDN.rad_to_hertz
@@ -194,6 +195,7 @@ State-Space Translators
 
    pyFDN.dss_to_ss
    pyFDN.dss_to_impz
+   pyFDN.build_impulse_response
    pyFDN.dss_to_tf
    pyFDN.dss_to_pr
    pyFDN.dss_to_flamo
@@ -225,7 +227,7 @@ Training
 
    pyFDN.build_fdn
    pyFDN.trainable_from_build
-   pyFDN.with_decay
+   pyFDN.build_set_decay
    pyFDN.Trainable
    pyFDN.train_fdn
    pyFDN.TrainLog
@@ -251,6 +253,15 @@ Plotting
    pyFDN.downsampled_scatter
    pyFDN.downsample_minmax
    pyFDN.downsample_plotly_trace
+
+Notebook Display
+----------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   pyFDN.labeled_audio
 
 FLAMO Graph
 -----------

--- a/examples/example_train_colorless_FDN.py
+++ b/examples/example_train_colorless_FDN.py
@@ -18,24 +18,13 @@ def _(mo):
     mo.md(r"""
     # Colorless FDN, trained in-notebook
 
-    The companion to **Colorless FDN**, which *loads* pre-optimized parameters
-    from `.mat` files. Here we run the optimization ourselves with `pyFDN`'s
-    training API, following *"Differentiable Feedback Delay Network for
-    Colorless Reverberation", Dal Santo, Prawda, Schlecht, Välimäki, DAFx23*
-    (and its "tiny colorless FDN" follow-up):
+    The companion to **Colorless FDN**, which *loads* pre-optimized parameters from `.mat` files. Here we run the optimization ourselves with `pyFDN`'s training API, following *"Differentiable Feedback Delay Network for Colorless Reverberation", Dal Santo, Prawda, Schlecht, Välimäki, DAFx23* (and its "tiny colorless FDN" follow-up):
 
-    1. `pyFDN.build_fdn` -- a standard FDN skeleton with random orthogonal feedback
-       matrix.
-    2. `pyFDN.train_fdn(model, "colorless")` -- optimize the feedback matrix and
-       gains for a flat magnitude (magnitude MSE + a feedback-matrix sparsity
-       penalty), in place.
-    3. `pyFDN.extract_build` -- read both the initial and
-       optimized FDNs back out.
+    1. `pyFDN.build_fdn` -- a standard FDN skeleton with random orthogonal feedback matrix.
+    2. `pyFDN.train_fdn(model, "colorless")` -- optimize the feedback matrix and gains for a flat magnitude (magnitude MSE + a feedback-matrix sparsity penalty), in place.
+    3. `pyFDN.extract_build` -- read both the initial and optimized FDNs back out.
 
-    Delays stay fixed. We then add homogeneous decay so the result is audible.
-    Flatness is measured on the magnitude response at the **training** FFT bins --
-    the right colorless measure for a lossless FDN, whose time response never
-    decays. Training is kept short so the example runs in a few seconds.
+    Delays stay fixed. We then add homogeneous decay so the result is audible. Flatness is measured on the magnitude response at the **training** FFT bins -- the right colorless measure for a lossless FDN, whose time response never decays. Training is kept short so the example runs in a few seconds.
 
     - pyFDN training pipeline: Jeremy B. Bai, 2026-06-19
     """)
@@ -81,7 +70,7 @@ def _(flatness, np, pyFDN):
         "colorless",
         optimizer="lbfgs",
         max_steps=2000,
-        lr=1e-3,
+        lr=1e-2,
         device="cpu",
         rng=1,
     )
@@ -140,43 +129,53 @@ def _(flatness, fs, log, mag_init, mag_opt, mo, nfft, np, pyFDN):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
+    ## FDN parameters: random init vs colorless
+
+    The stored `FDNBuild` parameters side by side -- delay lengths, the feedback matrix `A`, and the input/output/direct gains `b`, `c`, `d`, on a shared color scale. Training reshapes `A` and the gains (the delays stay fixed) to flatten the magnitude response.
+    """)
+    return
+
+
+@app.cell
+def _(init_build, mo, opt_build, pyFDN):
+    _build_init = pyFDN.plot_FDN_build(init_build, title="Random init")
+    _build_opt = pyFDN.plot_FDN_build(opt_build, title="Colorless")
+    mo.hstack([mo.as_html(_build_init), mo.as_html(_build_opt)], gap=2)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
     ## Listen: random init vs colorless
 
-    Two renderings of each FDN, built end to end through the render API
-    (`pyFDN.with_decay` -> `pyFDN.build_to_flamo` -> `pyFDN.flamo_time_response`),
-    peak-normalized so the A/B compares *timbre*, not level:
+    Two renderings of each FDN, built end to end through the render API (`pyFDN.build_set_decay` -> `pyFDN.build_impulse_response`), peak-normalized with `pyFDN.peak_normalize` so the A/B compares *timbre*, not level:
 
-    * **Long tail (hear the colour)** -- a very long reverberation time, so the FDN
-      rings with almost no decay and you hear its colour directly: the random init
-      is tonal/metallic (sharp modal resonances), the colorless one is noise-like
-      (flat spectrum). A *truly* lossless FDN (poles on the unit circle) can't be
-      rendered by the FFT-based `flamo_time_response` without time-aliasing the
-      colour away, so we use a long finite RT instead.
+    * **Long tail (hear the colour)** -- a very long reverberation time, so the FDN rings with almost no decay and you hear its colour directly: the random init is tonal/metallic (sharp modal resonances), the colorless one is noise-like (flat spectrum). `build_impulse_response` renders in the time domain (`pyFDN.process_fdn`), so the long ring is captured faithfully without the FFT wrap-around an nfft-length frequency-domain render would alias back onto the start.
     * **Reverb tail** -- a short homogeneous $T_{60}$, giving an audible decay.
     """)
     return
 
 
 @app.cell
-def _(fs, init_build, np, opt_build, pyFDN):
+def _(fs, init_build, opt_build, pyFDN):
     # A long "ring" RT keeps the colour audible with little decay; a short RT gives
     # an audible reverb tail.
     rt_ring, rt_rev = 60.0, 2.0
     n_samples = int(2.0 * fs)
 
     def render(build, rt):
-        """build -> FLAMO model with decay -> peak-normalized NumPy IR."""
-        model = pyFDN.build_to_flamo(
-            pyFDN.with_decay(build, rt), nfft=n_samples, device="cpu"
-        )
-        ir = pyFDN.flamo_time_response(model, fs=fs).squeeze()
+        """build (with homogeneous decay) -> peak-normalized 1-D impulse response."""
+        ir = pyFDN.build_impulse_response(
+            pyFDN.build_set_decay(build, rt), n_samples
+        ).squeeze()
         # peak-normalize so the A/B compares timbre at matched level, not loudness.
-        return np.asarray(ir) / (np.max(np.abs(ir)) + 1e-12)
+        return pyFDN.fade_out(pyFDN.peak_normalize(ir), 2048)
 
-    _fade = np.ones(n_samples)
-    _fade[-2048:] = np.linspace(1.0, 0.0, 2048)
-    init_noise = render(init_build, rt_ring) * _fade
-    opt_noise = render(opt_build, rt_ring) * _fade
+    # Long "ring": the tail is still loud at the buffer end, so fade it out to
+    # avoid a click on the abrupt cutoff.
+    init_noise = render(init_build, rt_ring)
+    opt_noise = render(opt_build, rt_ring)
 
     # Reverb: a short homogeneous T60 gives an audible decaying tail.
     init_decay = render(init_build, rt_rev)
@@ -186,13 +185,6 @@ def _(fs, init_build, np, opt_build, pyFDN):
 
 @app.cell
 def _(fs, init_decay, init_noise, mo, opt_decay, opt_noise, pyFDN):
-
-    def _clip(label, sig):
-        return mo.vstack(
-            [mo.Html(label).style({"font-size": "1.1em"}), mo.audio(sig, rate=int(fs))],
-            gap=0,
-        )
-
     _plot = pyFDN.plot_impulse_response(
         opt_decay, init_decay, fs=fs, labels=["Colorless", "Random init"]
     )
@@ -203,16 +195,16 @@ def _(fs, init_decay, init_noise, mo, opt_decay, opt_noise, pyFDN):
                     mo.Html("<b>Long tail (hear the colour)</b>").style(
                         {"font-size": "1.2em"}
                     ),
-                    _clip("Random init", init_noise),
-                    _clip("Colorless", opt_noise),
+                    pyFDN.labeled_audio("Random init", init_noise, fs=fs),
+                    pyFDN.labeled_audio("Colorless", opt_noise, fs=fs),
                 ],
                 gap=1,
             ),
             mo.vstack(
                 [
                     mo.Html("<b>Reverb tail</b>").style({"font-size": "1.2em"}),
-                    _clip("Random init", init_decay),
-                    _clip("Colorless", opt_decay),
+                    pyFDN.labeled_audio("Random init", init_decay, fs=fs),
+                    pyFDN.labeled_audio("Colorless", opt_decay, fs=fs),
                 ],
                 gap=1,
             ),

--- a/examples/example_train_colorless_FDN.py
+++ b/examples/example_train_colorless_FDN.py
@@ -149,9 +149,9 @@ def _(mo):
     mo.md(r"""
     ## Listen: random init vs colorless
 
-    Two renderings of each FDN, built end to end through the render API (`pyFDN.build_set_decay` -> `pyFDN.build_impulse_response`), peak-normalized with `pyFDN.peak_normalize` so the A/B compares *timbre*, not level:
+    Two renderings of each FDN, built end to end through the render API (`pyFDN.build_set_decay` -> `pyFDN.build_to_impz`), peak-normalized with `pyFDN.peak_normalize` so the A/B compares *timbre*, not level:
 
-    * **Long tail (hear the colour)** -- a very long reverberation time, so the FDN rings with almost no decay and you hear its colour directly: the random init is tonal/metallic (sharp modal resonances), the colorless one is noise-like (flat spectrum). `build_impulse_response` renders in the time domain (`pyFDN.process_fdn`), so the long ring is captured faithfully without the FFT wrap-around an nfft-length frequency-domain render would alias back onto the start.
+    * **Long tail (hear the colour)** -- a very long reverberation time, so the FDN rings with almost no decay and you hear its colour directly: the random init is tonal/metallic (sharp modal resonances), the colorless one is noise-like (flat spectrum). `build_to_impz` renders in the time domain (`pyFDN.process_fdn`), so the long ring is captured faithfully without the FFT wrap-around an nfft-length frequency-domain render would alias back onto the start.
     * **Reverb tail** -- a short homogeneous $T_{60}$, giving an audible decay.
     """)
     return
@@ -166,7 +166,7 @@ def _(fs, init_build, opt_build, pyFDN):
 
     def render(build, rt):
         """build (with homogeneous decay) -> peak-normalized 1-D impulse response."""
-        ir = pyFDN.build_impulse_response(
+        ir = pyFDN.build_to_impz(
             pyFDN.build_set_decay(build, rt), n_samples
         ).squeeze()
         # peak-normalize so the A/B compares timbre at matched level, not loudness.

--- a/src/pyFDN/__init__.py
+++ b/src/pyFDN/__init__.py
@@ -89,6 +89,7 @@ __all__ = [
     "db_to_lin",
     "db_to_sq",
     "ensure_3d",
+    "fade_out",
     "hertz_to_unit",
     "hertz_to_rad",
     "rad_to_hertz",
@@ -103,6 +104,7 @@ __all__ = [
     "pole_boundaries",
     "skew",
     # state-space translators
+    "build_impulse_response",
     "build_to_flamo",
     "dss_to_flamo",
     "dss_to_impz",
@@ -121,7 +123,7 @@ __all__ = [
     # training
     "build_fdn",
     "trainable_from_build",
-    "with_decay",
+    "build_set_decay",
     "Trainable",
     "train_fdn",
     "TrainLog",
@@ -140,6 +142,8 @@ __all__ = [
     "downsample_minmax",
     "downsample_plotly_trace",
     "downsampled_scatter",
+    # notebook display (marimo)
+    "labeled_audio",
     # FLAMO graph
     "flamo_model_to_nodes",
     "flamo_nodes_flat",
@@ -215,6 +219,7 @@ from .auxiliary.flamo_graph import (
     flamo_nodes_flat,
     plot_flamo_graph,
 )
+from .auxiliary.marimo_utils import labeled_audio
 
 # polynomial and matrix maths
 from .auxiliary.math import (
@@ -266,6 +271,7 @@ from .auxiliary.utils import (
     db_to_lin,
     db_to_sq,
     ensure_3d,
+    fade_out,
     hertz_to_rad,
     hertz_to_unit,
     is_bounding_curve,
@@ -355,14 +361,14 @@ from .train import (
     Trainable,
     TrainLog,
     build_fdn,
+    build_set_decay,
     train_fdn,
     trainable_from_build,
-    with_decay,
 )
 
 # state-space translators
 from .translate.dss_to_flamo import build_to_flamo, dss_to_flamo
-from .translate.dss_to_impz import dss_to_impz
+from .translate.dss_to_impz import build_impulse_response, dss_to_impz
 from .translate.dss_to_pr import dss_to_pr
 from .translate.dss_to_ss import dss_to_ss
 from .translate.dss_to_tf import dss_to_tf

--- a/src/pyFDN/__init__.py
+++ b/src/pyFDN/__init__.py
@@ -104,7 +104,7 @@ __all__ = [
     "pole_boundaries",
     "skew",
     # state-space translators
-    "build_impulse_response",
+    "build_to_impz",
     "build_to_flamo",
     "dss_to_flamo",
     "dss_to_impz",
@@ -368,7 +368,7 @@ from .train import (
 
 # state-space translators
 from .translate.dss_to_flamo import build_to_flamo, dss_to_flamo
-from .translate.dss_to_impz import build_impulse_response, dss_to_impz
+from .translate.dss_to_impz import build_to_impz, dss_to_impz
 from .translate.dss_to_pr import dss_to_pr
 from .translate.dss_to_ss import dss_to_ss
 from .translate.dss_to_tf import dss_to_tf

--- a/src/pyFDN/auxiliary/marimo_utils.py
+++ b/src/pyFDN/auxiliary/marimo_utils.py
@@ -1,0 +1,48 @@
+"""marimo display helpers used by the example notebooks.
+
+marimo is an optional dependency (the ``examples`` / ``test`` extras), so it is
+imported lazily inside each helper -- importing pyFDN never requires marimo.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def labeled_audio(
+    label: str,
+    signal: ArrayLike,
+    *,
+    fs: float,
+    label_size: str = "1.1em",
+    gap: float = 0,
+) -> Any:
+    """Stack a text ``label`` above an audio player (a marimo element).
+
+    Convenience for A/B listening layouts: returns ``mo.vstack([label, audio])``
+    with ``label`` rendered as sized HTML and ``signal`` as an ``mo.audio``
+    player at ``fs``. marimo is imported lazily, so this only requires marimo
+    when actually called.
+
+    Args:
+        label: HTML/text shown above the player.
+        signal: Audio samples passed to ``mo.audio``.
+        fs: Sample rate in Hz.
+        label_size: CSS ``font-size`` for the label (default ``"1.1em"``).
+        gap: Vertical gap between the label and the player (default 0).
+
+    Returns:
+        A marimo ``vstack`` element.
+    """
+    import marimo as mo
+
+    return mo.vstack(
+        [
+            mo.Html(label).style({"font-size": label_size}),
+            mo.audio(np.asarray(signal), rate=int(fs)),
+        ],
+        gap=gap,
+    )

--- a/src/pyFDN/auxiliary/utils.py
+++ b/src/pyFDN/auxiliary/utils.py
@@ -175,6 +175,29 @@ def peak_normalize(x: ArrayLike, target_peak: float = 1.0) -> np.ndarray:
     return x
 
 
+def fade_out(x: ArrayLike, fade_samples: int) -> np.ndarray:
+    """Apply a linear fade-out over the last ``fade_samples`` samples.
+
+    Ramps the tail of ``x`` linearly from 1 to 0 along the last axis, so a
+    finite render can end at zero instead of clicking on an abrupt cutoff.
+
+    Args:
+        x: Input signal; the fade is applied along the last axis.
+        fade_samples: Number of trailing samples to ramp down. Clamped to the
+            signal length; values <= 0 leave the signal unchanged.
+
+    Returns:
+        Faded copy of ``x`` (float), same shape as the input. ``x`` is not
+        modified in place.
+    """
+    x = np.asarray(x, dtype=float).copy()
+    k = int(min(fade_samples, x.shape[-1]))
+    if k <= 0:
+        return x
+    x[..., -k:] *= np.linspace(1.0, 0.0, k)
+    return x
+
+
 def hertz_to_unit(hz: ArrayLike, fs: float) -> np.ndarray:
     """Convert frequency (Hz) to normalised frequency (0-1)."""
     return np.asarray(hz) / fs * 2

--- a/src/pyFDN/train/__init__.py
+++ b/src/pyFDN/train/__init__.py
@@ -11,7 +11,13 @@
 
 from __future__ import annotations
 
-from .build import MatrixParam, Trainable, build_fdn, trainable_from_build, with_decay
+from .build import (
+    MatrixParam,
+    Trainable,
+    build_fdn,
+    build_set_decay,
+    trainable_from_build,
+)
 from .engine import TrainLog, train_fdn
 from .objectives import Objective
 
@@ -19,7 +25,7 @@ __all__ = [
     # build
     "build_fdn",
     "trainable_from_build",
-    "with_decay",
+    "build_set_decay",
     "Trainable",
     "MatrixParam",
     # train

--- a/src/pyFDN/train/build.py
+++ b/src/pyFDN/train/build.py
@@ -255,7 +255,7 @@ def trainable_from_build(
     return wrap_fdn_shell(core, nfft=nfft, dtype=dtype, output=output)
 
 
-def with_decay(
+def build_set_decay(
     build: FDNBuild,
     rt: float | tuple[float, float],
     *,
@@ -277,7 +277,7 @@ def with_decay(
 
 
 def _rt_pair(rt: float | tuple[float, float]) -> tuple[float, float]:
-    if isinstance(rt, (tuple, list)):
+    if isinstance(rt, tuple | list):
         return float(rt[0]), float(rt[1])
     return float(rt), float(rt)
 

--- a/src/pyFDN/train/engine.py
+++ b/src/pyFDN/train/engine.py
@@ -91,7 +91,6 @@ def train_fdn(
         Checkpoint directory (used when ``log=True``).
     """
     import torch
-
     from flamo.optimize.trainer import EagerTrainer
 
     from pyFDN.auxiliary.flamo import output_layer
@@ -125,6 +124,7 @@ def train_fdn(
     # Checkpoint only when logging to a directory; EagerTrainer asserts it exists.
     save_checkpoints = log and train_dir is not None
     if save_checkpoints:
+        assert train_dir is not None  # implied by save_checkpoints
         os.makedirs(train_dir, exist_ok=True)
     trainer = EagerTrainer(
         model,
@@ -146,9 +146,7 @@ def train_fdn(
     steps_run = len(train_loss)
     return TrainLog(
         train_loss=train_loss,
-        loss_log={
-            k: [float(x) for x in v] for k, v in history.items() if k != "total"
-        },
+        loss_log={k: [float(x) for x in v] for k, v in history.items() if k != "total"},
         steps_run=steps_run,
         stopped_early=steps_run < max_steps,
     )
@@ -182,5 +180,3 @@ def _model_info(model: Any) -> tuple[int, int, float]:
         int(_gain("output_gain").param.shape[0]),
         fs,
     )
-
-

--- a/src/pyFDN/translate/dss_to_impz.py
+++ b/src/pyFDN/translate/dss_to_impz.py
@@ -55,7 +55,7 @@ def dss_to_impz(
     return np.stack(out_list, axis=-1)
 
 
-def build_impulse_response(build: FDNBuild, ir_len: int) -> np.ndarray:
+def build_to_impz(build: FDNBuild, ir_len: int) -> np.ndarray:
     """Render an :class:`FDNBuild` to a time-domain impulse response.
 
     Time-domain sibling of the FLAMO render path (:func:`pyFDN.build_to_flamo`
@@ -94,7 +94,7 @@ def build_impulse_response(build: FDNBuild, ir_len: int) -> np.ndarray:
 
     if build.post_eq is not None:
         raise ValueError(
-            "build_impulse_response does not apply build.post_eq (output EQ); "
+            "build_to_impz does not apply build.post_eq (output EQ); "
             "use build_to_flamo + flamo_time_response for output-EQ builds."
         )
 

--- a/src/pyFDN/translate/dss_to_impz.py
+++ b/src/pyFDN/translate/dss_to_impz.py
@@ -1,8 +1,15 @@
 # dss_to_impz.py
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 from numpy.typing import ArrayLike
 
 from pyFDN.process import process_fdn
+
+if TYPE_CHECKING:
+    from pyFDN.generate.fdn_matrix_gallery import FDNBuild
 
 
 def dss_to_impz(
@@ -41,6 +48,79 @@ def dss_to_impz(
         input_signal = np.zeros((ir_len, num_inputs))
         input_signal[0, j] = 1.0
         out_j = process_fdn(input_signal, delays, A, B, C, D)
+        if out_j.ndim == 1:
+            out_j = out_j[:, np.newaxis]
+        out_list.append(out_j)
+
+    return np.stack(out_list, axis=-1)
+
+
+def build_impulse_response(build: FDNBuild, ir_len: int) -> np.ndarray:
+    """Render an :class:`FDNBuild` to a time-domain impulse response.
+
+    Time-domain sibling of the FLAMO render path (:func:`pyFDN.build_to_flamo`
+    -> :func:`pyFDN.flamo_time_response`): runs one :func:`pyFDN.process_fdn`
+    block simulation per input channel (a Dirac on that channel), with the
+    build's per-delay-line absorption (``build.filters``, e.g. from
+    :func:`pyFDN.build_set_decay`) applied inside the loop as a
+    :class:`pyFDN.SOSFilterBank`. Unlike the FFT-based FLAMO render this does
+    not time-alias, so a long or near-lossless decay is rendered faithfully up
+    to ``ir_len``.
+
+    Extends :func:`dss_to_impz` (numeric state-space only) with the build's
+    absorption filters.
+
+    Parameters
+    ----------
+    build : FDNBuild
+        Complete FDN parameters.
+    ir_len : int
+        Impulse-response length in samples.
+
+    Returns
+    -------
+    np.ndarray
+        Impulse response of shape ``(ir_len, num_outputs, num_inputs)``. Use
+        ``.squeeze()`` for a 1-D array from a single-in/single-out FDN.
+
+    Raises
+    ------
+    ValueError
+        If ``build.post_eq`` is set: output EQ is not applied by
+        :func:`process_fdn`. Use :func:`pyFDN.build_to_flamo` +
+        :func:`pyFDN.flamo_time_response` for output-EQ builds.
+    """
+    from pyFDN.dsp.sos_filter_bank import SOSFilterBank
+
+    if build.post_eq is not None:
+        raise ValueError(
+            "build_impulse_response does not apply build.post_eq (output EQ); "
+            "use build_to_flamo + flamo_time_response for output-EQ builds."
+        )
+
+    n = np.asarray(build.A).shape[0]
+    num_inputs = np.asarray(build.B).shape[1]
+
+    out_list = []
+    for j in range(num_inputs):
+        # A fresh filter bank per channel so absorption state does not leak
+        # between the per-input simulations (SOSFilterBank is stateful).
+        absorption = (
+            SOSFilterBank(sos=build.filters, num_channels=n)
+            if build.filters is not None
+            else None
+        )
+        input_signal = np.zeros((ir_len, num_inputs))
+        input_signal[0, j] = 1.0
+        out_j = process_fdn(
+            input_signal,
+            build.delays,
+            build.A,
+            build.B,
+            build.C,
+            build.D,
+            absorption=absorption,
+        )
         if out_j.ndim == 1:
             out_j = out_j[:, np.newaxis]
         out_list.append(out_j)

--- a/tests/test_auxiliary_utils.py
+++ b/tests/test_auxiliary_utils.py
@@ -15,6 +15,7 @@ from pyFDN.auxiliary.delay import ms_to_smp
 from pyFDN.auxiliary.math import negpolyder, outer_sum_approximation, polyder_rational
 from pyFDN.auxiliary.utils import (
     ensure_3d,
+    fade_out,
     hertz_to_unit,
     is_bounding_curve,
     last_nonzero_indices,
@@ -273,3 +274,35 @@ def test_max_corr_zero_signal_yields_zero_row():
     M = max_corr(signals)
     assert M[0, 1] == 0.0
     assert M[1, 1] == 0.0
+
+
+# ============================================================================
+# fade_out
+# ============================================================================
+
+
+def test_fade_out_ramps_tail_to_zero_and_leaves_head():
+    x = np.ones(100)
+    y = fade_out(x, 10)
+    np.testing.assert_array_equal(y[:90], 1.0)  # head untouched
+    np.testing.assert_allclose(y[90:], np.linspace(1.0, 0.0, 10))
+    assert y[-1] == 0.0
+    np.testing.assert_array_equal(x, np.ones(100))  # input not mutated
+
+
+def test_fade_out_clamps_to_length_and_noops_on_nonpositive():
+    x = np.arange(5, dtype=float)
+    # fade longer than the signal clamps to the full length
+    np.testing.assert_allclose(fade_out(x, 999), x * np.linspace(1.0, 0.0, 5))
+    # a non-positive fade returns an unmodified copy (not the same object)
+    y = fade_out(x, 0)
+    np.testing.assert_array_equal(y, x)
+    assert y is not x
+
+
+def test_fade_out_applies_along_last_axis():
+    y = fade_out(np.ones((3, 8)), 4)
+    ramp = np.linspace(1.0, 0.0, 4)
+    for row in y:
+        np.testing.assert_array_equal(row[:4], 1.0)
+        np.testing.assert_allclose(row[4:], ramp)

--- a/tests/test_process_extensions.py
+++ b/tests/test_process_extensions.py
@@ -13,7 +13,7 @@ from pyFDN.auxiliary.math import general_char_poly
 from pyFDN.dsp.dfilt_matrix import FIRMatrixFilter
 from pyFDN.generate.fdn_matrix_gallery import FDNBuild
 from pyFDN.train import build_set_decay
-from pyFDN.translate.dss_to_impz import build_impulse_response, dss_to_impz
+from pyFDN.translate.dss_to_impz import build_to_impz, dss_to_impz
 
 FDNFixture = dict[str, np.ndarray]
 
@@ -217,7 +217,7 @@ def test_dss_to_flamo_output_filter_matches_sosfilt() -> None:
 
 
 # ============================================================================
-# build_impulse_response (build -> time-domain IR via process_fdn)
+# build_to_impz (build -> time-domain IR via process_fdn)
 # ============================================================================
 
 
@@ -234,25 +234,25 @@ def _siso_build(filters: np.ndarray | None = None) -> FDNBuild:
     )
 
 
-def test_build_impulse_response_lossless_matches_dss_to_impz() -> None:
+def test_build_to_impz_lossless_matches_dss_to_impz() -> None:
     np.random.seed(3)
     build = _siso_build()  # filters=None -> no absorption
     ir_len = 4096
-    got = build_impulse_response(build, ir_len)
+    got = build_to_impz(build, ir_len)
     ref = dss_to_impz(ir_len, build.delays, build.A, build.B, build.C, build.D)
     assert got.shape == (ir_len, 1, 1)
     np.testing.assert_allclose(got, ref)
 
 
-def test_build_impulse_response_applies_absorption_decay() -> None:
+def test_build_to_impz_applies_absorption_decay() -> None:
     np.random.seed(3)
     lossless = _siso_build()
     decayed = build_set_decay(lossless, 0.3)
     assert decayed.filters is not None
 
     ir_len = 16384
-    ir_loss = build_impulse_response(lossless, ir_len).squeeze()
-    ir_dec = build_impulse_response(decayed, ir_len).squeeze()
+    ir_loss = build_to_impz(lossless, ir_len).squeeze()
+    ir_dec = build_to_impz(decayed, ir_len).squeeze()
 
     # A lossless orthogonal FDN rings on; a 0.3 s RT is nearly gone by the
     # second half of the buffer, so its tail energy is far lower.
@@ -260,7 +260,7 @@ def test_build_impulse_response_applies_absorption_decay() -> None:
     assert np.sum(ir_dec[tail] ** 2) < 1e-2 * np.sum(ir_loss[tail] ** 2)
 
 
-def test_build_impulse_response_rejects_post_eq() -> None:
+def test_build_to_impz_rejects_post_eq() -> None:
     build = dataclasses.replace(_siso_build(), post_eq=np.zeros((1, 6, 1)))
     with pytest.raises(ValueError, match="post_eq"):
-        build_impulse_response(build, 128)
+        build_to_impz(build, 128)

--- a/tests/test_process_extensions.py
+++ b/tests/test_process_extensions.py
@@ -3,12 +3,17 @@ the paraunitary / scattering / pole-boundary examples)."""
 
 from __future__ import annotations
 
+import dataclasses
+
 import numpy as np
 import pytest
 
 import pyFDN
 from pyFDN.auxiliary.math import general_char_poly
 from pyFDN.dsp.dfilt_matrix import FIRMatrixFilter
+from pyFDN.generate.fdn_matrix_gallery import FDNBuild
+from pyFDN.train import build_set_decay
+from pyFDN.translate.dss_to_impz import build_impulse_response, dss_to_impz
 
 FDNFixture = dict[str, np.ndarray]
 
@@ -209,3 +214,53 @@ def test_dss_to_flamo_output_filter_matches_sosfilt() -> None:
         :ir_len
     ]
     np.testing.assert_allclose(ir_eq, sosfilt(eq_sos, ir_plain), atol=1e-8)
+
+
+# ============================================================================
+# build_impulse_response (build -> time-domain IR via process_fdn)
+# ============================================================================
+
+
+def _siso_build(filters: np.ndarray | None = None) -> FDNBuild:
+    n = 4
+    return FDNBuild(
+        A=pyFDN.random_orthogonal(n),
+        B=np.ones((n, 1)),
+        C=np.ones((1, n)),
+        D=np.zeros((1, 1)),
+        delays=np.array([101, 143, 165, 177]),
+        fs=48000.0,
+        filters=filters,
+    )
+
+
+def test_build_impulse_response_lossless_matches_dss_to_impz() -> None:
+    np.random.seed(3)
+    build = _siso_build()  # filters=None -> no absorption
+    ir_len = 4096
+    got = build_impulse_response(build, ir_len)
+    ref = dss_to_impz(ir_len, build.delays, build.A, build.B, build.C, build.D)
+    assert got.shape == (ir_len, 1, 1)
+    np.testing.assert_allclose(got, ref)
+
+
+def test_build_impulse_response_applies_absorption_decay() -> None:
+    np.random.seed(3)
+    lossless = _siso_build()
+    decayed = build_set_decay(lossless, 0.3)
+    assert decayed.filters is not None
+
+    ir_len = 16384
+    ir_loss = build_impulse_response(lossless, ir_len).squeeze()
+    ir_dec = build_impulse_response(decayed, ir_len).squeeze()
+
+    # A lossless orthogonal FDN rings on; a 0.3 s RT is nearly gone by the
+    # second half of the buffer, so its tail energy is far lower.
+    tail = slice(ir_len // 2, None)
+    assert np.sum(ir_dec[tail] ** 2) < 1e-2 * np.sum(ir_loss[tail] ** 2)
+
+
+def test_build_impulse_response_rejects_post_eq() -> None:
+    build = dataclasses.replace(_siso_build(), post_eq=np.zeros((1, 6, 1)))
+    with pytest.raises(ValueError, match="post_eq"):
+        build_impulse_response(build, 128)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -11,9 +11,9 @@ from pyFDN.generate.fdn_matrix_gallery import FDNBuild  # noqa: E402
 from pyFDN.train import (  # noqa: E402
     Trainable,
     build_fdn,
+    build_set_decay,
     train_fdn,
     trainable_from_build,
-    with_decay,
 )
 
 # Tiny / CPU / fast optimization settings.
@@ -167,9 +167,7 @@ def test_match_spectrogram_runs_and_renders():
     assert np.isfinite(log.train_loss[-1])
     out_ir = np.asarray(
         pyFDN.flamo_time_response(
-            pyFDN.build_to_flamo(
-                pyFDN.extract_build(fresh), nfft=nfft, device="cpu"
-            ),
+            pyFDN.build_to_flamo(pyFDN.extract_build(fresh), nfft=nfft, device="cpu"),
             fs=48000,
         )
     ).reshape(-1)
@@ -204,23 +202,34 @@ def test_match_spectrogram_mimo_target():
     nfft, N, n_in, n_out = 2**11, 4, 2, 2
     rng = np.random.default_rng(0)
     ref = build_fdn(
-        N=N, rt=0.05, nfft=nfft,
+        N=N,
+        rt=0.05,
+        nfft=nfft,
         input_gain=rng.standard_normal((N, n_in)),
         output_gain=rng.standard_normal((n_out, N)),
-        device="cpu", rng=0,
+        device="cpu",
+        rng=0,
     )
     target = _mimo_ir(ref, nfft, n_in, n_out)
     assert target.shape == (nfft, n_out, n_in)
 
     fresh = build_fdn(
-        N=N, rt=0.05, nfft=nfft,
+        N=N,
+        rt=0.05,
+        nfft=nfft,
         input_gain=rng.standard_normal((N, n_in)),
         output_gain=rng.standard_normal((n_out, N)),
-        device="cpu", rng=9,
+        device="cpu",
+        rng=9,
     )
     log = train_fdn(
-        fresh, "match_spectrogram", target=target,
-        mss_nfft=(256, 512), max_steps=20, rng=0, **_FAST,
+        fresh,
+        "match_spectrogram",
+        target=target,
+        mss_nfft=(256, 512),
+        max_steps=20,
+        rng=0,
+        **_FAST,
     )
     assert np.isfinite(log.train_loss[-1])
     assert log.train_loss[-1] <= log.train_loss[0]
@@ -228,9 +237,13 @@ def test_match_spectrogram_mimo_target():
 
 def test_mimo_target_wrong_shape_raises():
     model = build_fdn(
-        N=4, rt=None, nfft=2**10,
-        input_gain=np.ones((4, 2)), output_gain=np.ones((2, 4)),
-        device="cpu", rng=0,
+        N=4,
+        rt=None,
+        nfft=2**10,
+        input_gain=np.ones((4, 2)),
+        output_gain=np.ones((2, 4)),
+        device="cpu",
+        rng=0,
     )
     bad = np.zeros((128, 3, 2))  # n_out=3 != model's 2
     with pytest.raises(ValueError, match="MIMO target must have shape"):
@@ -240,11 +253,11 @@ def test_mimo_target_wrong_shape_raises():
 # --- analytic decay (the exact RT path) ------------------------------------
 
 
-def test_with_decay_realizes_rt():
+def test_build_set_decay_realizes_rt():
     build = pyFDN.extract_build(
         build_fdn(N=6, rt=None, nfft=2**12, device="cpu", rng=3)
     )
-    build = with_decay(build, 0.3)
+    build = build_set_decay(build, 0.3)
     assert build.filters is not None and build.filters.shape == (1, 6, 6)
 
     ir = np.asarray(


### PR DESCRIPTION
Add `build_impulse_response` for time-domain FDN rendering (avoids FFT aliasing), `fade_out` for linear tail attenuation, and `labeled_audio` for marimo A/B listening layouts. Rename `with_decay` to `build_set_decay` for clarity. Update example notebook to use the new functions and simplify audio rendering code.

## Summary
<!-- What does this PR do? Link the relevant issue if applicable. -->

Fixes #

## Changes
<!-- Brief bullet list of what changed -->
-

## Testing
- [ ] `pytest` passes locally
- [ ] New tests added for new functionality
- [ ] Coverage not decreased (`pytest --cov=pyFDN`)

## Checklist
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Docstrings updated for any changed public API
- [ ] `HISTORY.rst` updated if this is a user-facing change
