### PR TITLE
Add support for training with in-loop filters

### DIFF
--- a/src/pyFDN/auxiliary/delay.py
+++ b/src/pyFDN/auxiliary/delay.py
@@ -59,8 +59,8 @@ def flamo_delay_feedback_matrix(
 
     target = model if inplace else copy.deepcopy(model)
     feedback_loop = target.get_core().branchA.feedback_loop
-    base_delay = feedback_loop.feedforward
-    feedback_matrix = feedback_loop.feedback
+    base_delay = feedback_loop.feedforward.delay
+    feedback_matrix = feedback_loop.feedback.mixing_matrix
 
     _assign_flamo_delay_samples(base_delay, delay_vectors[0])
     extra_delay_in = copy.deepcopy(base_delay)

--- a/src/pyFDN/auxiliary/flamo.py
+++ b/src/pyFDN/auxiliary/flamo.py
@@ -503,7 +503,7 @@ def assemble_fdn_core(
     feedback: Any,
     delays: Any,
     output_gain: Any,
-    direct: Any = None,
+    direct: Any,
     loop_filter: Any = None,
     output_filter: Any = None,
     post_delay_module: Any = None,
@@ -511,48 +511,33 @@ def assemble_fdn_core(
     """
     Wire pre-built FLAMO modules into an FDN core (no FFT/iFFT wrapping).
 
-    Single source of truth for the FDN signal flow, shared by the render path
-    (:func:`pyFDN.dss_to_flamo`) and the training builder
-    (:func:`pyFDN.train.trainable_from_build`). All arguments are already-built
-    FLAMO ``dsp``/``system`` modules; this only composes them, so leaf names and
-    topology stay identical across both callers (and match the names
-    :func:`pyFDN.extract_build` looks for).
-
-    Signal flow::
+    Returns ``Parallel(brA=fdn_branch, brB=direct)``. Signal flow::
 
         input_gain -> [recursion: delay -> (loop_filter) -> (post_delay_module); fB = feedback]
-                   -> output_gain -> (output_filter)
-
-    with the direct path ``direct`` summed in parallel when provided.
+                   -> output_gain -> (output_filter)   +   direct
 
     Parameters
     ----------
     input_gain, output_gain : FLAMO modules
-        Input gain ``B`` (named ``input_gain``) and output gain ``C`` (named
+        Input gain ``B`` (leaf ``input_gain``) and output gain ``C`` (leaf
         ``output_gain``).
     feedback : FLAMO module
-        Feedback matrix placed on the recursion feedback branch (``fB``); a
-        plain ``Gain``/``Filter`` (render) or a parametrized ``Matrix``
-        (training).
+        Feedback matrix (leaf ``mixing_matrix``).
     delays : FLAMO module
-        Delay module on the recursion forward branch (named ``delay``).
-    direct : FLAMO module or None
-        Direct path ``D``. When ``None`` the core is the plain feedforward
-        ``Series`` (no ``Parallel`` wrapper) -- this keeps ``core.feedback_loop``
-        reachable for losses such as ``sparsity_loss``. When provided the core
-        is ``Parallel(brA=fdn_branch, brB=direct)``.
+        Delay module (leaf ``delay``).
+    direct : FLAMO module
+        Direct path ``D`` (leaf ``direct_gain``). Pass a zero gain for no direct
+        path.
     loop_filter : FLAMO module or None
-        Optional in-loop filter after the delays (named ``filter``).
+        Optional in-loop filter after the delays (leaf ``filter``).
     output_filter : FLAMO module or None
-        Optional per-output filter after the output gain (named
-        ``output_filter``).
+        Optional per-output filter after the output gain (leaf ``output_filter``).
     post_delay_module : FLAMO module or None
         Optional module appended after the delay in the recursion.
 
     Returns
     -------
-    core : flamo.processor.system.Series or Parallel
-        The FDN core, ready for :func:`wrap_fdn_shell`.
+    core : flamo.processor.system.Parallel
     """
     if not _HAS_FLAMO:
         raise ImportError("assemble_fdn_core requires flamo (pip install flamo)")
@@ -560,42 +545,36 @@ def assemble_fdn_core(
 
     from flamo.processor import system
 
+    from pyFDN.auxiliary import flamo_graph as layout
+
+    forward = OrderedDict({layout.DELAY: delays})
     if loop_filter is not None:
-        delay_chain = system.Series(
-            OrderedDict({"delay": delays, "filter": loop_filter})
-        )
-    else:
-        delay_chain = delays
-
+        forward[layout.LOOP_FILTER] = loop_filter
     if post_delay_module is not None:
-        delay_chain = system.Series(
-            OrderedDict({"delay": delay_chain, "post_delay_module": post_delay_module})
-        )
+        forward["post_delay_module"] = post_delay_module
 
-    feedback_loop = system.Recursion(fF=delay_chain, fB=feedback)
+    feedback_branch = system.Series(OrderedDict({layout.MIXING_MATRIX: feedback}))
+    feedback_loop = system.Recursion(fF=system.Series(forward), fB=feedback_branch)
     fdn_modules = OrderedDict(
         {
-            "input_gain": input_gain,
+            layout.INPUT_GAIN: input_gain,
             "feedback_loop": feedback_loop,
-            "output_gain": output_gain,
+            layout.OUTPUT_GAIN: output_gain,
         }
     )
     if output_filter is not None:
-        fdn_modules["output_filter"] = output_filter
+        fdn_modules[layout.OUTPUT_FILTER] = output_filter
     fdn_branch = system.Series(fdn_modules)
 
-    if direct is not None:
-        return system.Parallel(brA=fdn_branch, brB=direct, sum_output=True)
-    return fdn_branch
+    direct_branch = system.Series(OrderedDict({layout.DIRECT: direct}))
+    return system.Parallel(brA=fdn_branch, brB=direct_branch, sum_output=True)
 
 
 def output_layer(output: str, nfft: int, dtype: Any = None) -> Any:
     """Build the FLAMO output layer for an output domain.
 
     ``"time"`` -> ``iFFT`` (time response); ``"magnitude"`` -> ``|.|`` of the
-    frequency response. The single source of truth for the ``output``-string ->
-    layer mapping, shared by :func:`wrap_fdn_shell` (build time) and the training
-    output-domain swap (:func:`pyFDN.train_fdn`) so the two cannot disagree.
+    frequency response.
     """
     if not _HAS_FLAMO:
         raise ImportError("output_layer requires flamo (pip install flamo)")
@@ -624,12 +603,8 @@ def wrap_fdn_shell(
     dtype : torch.dtype or None
         Dtype for the FFT/iFFT layers; defaults to float32.
     output : str
-        Output-domain layer:
-
-        * ``"time"`` -- ``iFFT`` time response (the render default, matching
-          :func:`pyFDN.dss_to_flamo`).
-        * ``"magnitude"`` -- ``|.|`` of the frequency response, for
-          magnitude-domain losses (e.g. colorless training).
+        Output-domain layer: ``"time"`` (``iFFT`` time response) or
+        ``"magnitude"`` (``|.|`` of the frequency response).
 
     Returns
     -------

--- a/src/pyFDN/auxiliary/flamo_graph.py
+++ b/src/pyFDN/auxiliary/flamo_graph.py
@@ -16,6 +16,24 @@ if TYPE_CHECKING:
     from pyFDN.generate.fdn_matrix_gallery import FDNBuild
 
 
+# Canonical names of a standard FDN's flamo graph, written by
+# :func:`pyFDN.assemble_fdn_core` and read by :func:`extract_build`.
+INPUT_GAIN = "input_gain"
+OUTPUT_GAIN = "output_gain"
+MIXING_MATRIX = "mixing_matrix"
+DELAY = "delay"
+LOOP_FILTER = "filter"
+OUTPUT_FILTER = "output_filter"
+DIRECT = "direct_gain"
+LOOP_FILTER_ALIASES = (LOOP_FILTER, "attenuation")
+
+# Structural branch labels assigned by the traversal.
+BRANCH_FDN = "fdn"
+BRANCH_DIRECT = "direct"
+BRANCH_FEEDFORWARD = "feedforward"
+BRANCH_FEEDBACK = "feedback"
+
+
 # Traversal uses type(module).__name__ and getattr; no need to import flamo here.
 
 
@@ -159,11 +177,15 @@ def flamo_model_to_nodes(
         children = []
         if brA is not None:
             children.append(
-                flamo_model_to_nodes(brA, name="brA", include_shell_io=include_shell_io)
+                flamo_model_to_nodes(
+                    brA, name=BRANCH_FDN, include_shell_io=include_shell_io
+                )
             )
         if brB is not None:
             children.append(
-                flamo_model_to_nodes(brB, name="brB", include_shell_io=include_shell_io)
+                flamo_model_to_nodes(
+                    brB, name=BRANCH_DIRECT, include_shell_io=include_shell_io
+                )
             )
         node["children"] = children
         return node
@@ -173,12 +195,16 @@ def flamo_model_to_nodes(
         fF = getattr(model, "fF", None) or getattr(model, "feedforward", None)
         fB = getattr(model, "fB", None) or getattr(model, "feedback", None)
         node["fF"] = (
-            flamo_model_to_nodes(fF, name="fF", include_shell_io=include_shell_io)
+            flamo_model_to_nodes(
+                fF, name=BRANCH_FEEDFORWARD, include_shell_io=include_shell_io
+            )
             if fF is not None
             else None
         )
         node["fB"] = (
-            flamo_model_to_nodes(fB, name="fB", include_shell_io=include_shell_io)
+            flamo_model_to_nodes(
+                fB, name=BRANCH_FEEDBACK, include_shell_io=include_shell_io
+            )
             if fB is not None
             else None
         )
@@ -221,7 +247,7 @@ def flamo_nodes_flat(
         for key in ("fF", "fB"):
             child = root.get(key)
             if child is not None:
-                subpath = f"{path}/{key}"
+                subpath = f"{path}/{child['name']}"
                 out.extend(flamo_nodes_flat(child, path=subpath))
     return out
 
@@ -267,13 +293,7 @@ def _gain_to_sos(gain: np.ndarray) -> np.ndarray:
 
 
 def _svf_to_sos(module: Any) -> np.ndarray:
-    """Bake a flamo ``parallelSVF`` into an ``(n_sections, 6, N)`` SOS bank.
-
-    Each SVF section is a biquad whose coefficients are flamo's closed form of
-    the mapped parameters ``(f, R, mLP, mBP, mHP) = map_param2svf(param)``. The
-    section is normalized so ``a0 == 1`` (the SOS convention; ``H = B/A`` is
-    unchanged), giving a bank the render path consumes like any other.
-    """
+    """Bake a flamo ``parallelSVF`` into a normalized ``(n_sections, 6, N)`` SOS bank."""
 
     def _np(t: Any) -> np.ndarray:
         if hasattr(t, "detach"):
@@ -283,26 +303,23 @@ def _svf_to_sos(module: Any) -> np.ndarray:
         return np.asarray(t.numpy() if hasattr(t, "numpy") else t, dtype=float)
 
     f, r, m_lp, m_bp, m_hp = (_np(t) for t in module.map_param2svf(module.param))
-    # broadcast a scalar R (lowshelf/highshelf) up to (n_sections, N)
     f, r, m_lp, m_bp, m_hp = np.broadcast_arrays(f, r, m_lp, m_bp, m_hp)
+    a0 = f**2 + 2.0 * r * f + 1.0
     sos = np.empty((*f.shape, 6), dtype=float)
-    sos[..., 0] = f**2 * m_lp + f * m_bp + m_hp
-    sos[..., 1] = 2.0 * f**2 * m_lp - 2.0 * m_hp
-    sos[..., 2] = f**2 * m_lp - f * m_bp + m_hp
-    sos[..., 3] = f**2 + 2.0 * r * f + 1.0
-    sos[..., 4] = 2.0 * f**2 - 2.0
-    sos[..., 5] = f**2 - 2.0 * r * f + 1.0
-    # (n_sections, N, 6) -> (n_sections, 6, N)
+    sos[..., 0] = (f**2 * m_lp + f * m_bp + m_hp) / a0
+    sos[..., 1] = (2.0 * f**2 * m_lp - 2.0 * m_hp) / a0
+    sos[..., 2] = (f**2 * m_lp - f * m_bp + m_hp) / a0
+    sos[..., 3] = 1.0
+    sos[..., 4] = (2.0 * f**2 - 2.0) / a0
+    sos[..., 5] = (f**2 - 2.0 * r * f + 1.0) / a0
     return np.ascontiguousarray(np.moveaxis(sos, -1, 1))
 
 
 def _attenuation_to_sos(module: Any) -> np.ndarray:
     """In-loop filter module -> ``(n_sections, 6, N)`` SOS for ``FDNBuild.filters``.
 
-    Biquad-cascade IIR filters are baked to SOS: ``parallelSVF`` via its closed
-    form, ``parallelSOSFilter`` (and a plain broadband gain) via its value. Other
-    types -- graphic/parametric EQs and FIR -- have no SOS extractor yet and
-    raise rather than silently dropping the trained filter.
+    Supports ``parallelSVF`` and ``parallelSOSFilter`` (and a plain broadband
+    gain); other filter types raise.
     """
     type_name = type(module).__name__
     if "SVF" in type_name:
@@ -320,21 +337,13 @@ def _attenuation_to_sos(module: Any) -> np.ndarray:
 
 
 def _feedback_leaf_module(leaves: list[dict[str, Any]]) -> Any:
-    """The single feedback-matrix leaf module from a flat leaf list.
+    """The single feedback-matrix leaf module (named ``mixing_matrix``).
 
-    Accepts a ``mixing_matrix`` leaf or the standard recursion feedback leaf
-    ``fB`` (preferring the one at ``.../feedback_loop/fB`` so a Parallel direct
-    branch does not confuse it). Returns the **live** module (``.map``/``.param``
-    intact). Callers that need gradients must apply ``.map`` themselves rather
-    than going through :func:`_module_value`, which detaches.
+    Returns the **live** module (``.map``/``.param`` intact); callers that need
+    gradients must apply ``.map`` themselves rather than going through
+    :func:`_module_value`, which detaches.
     """
-    matches = [n for n in leaves if n["name"] == "mixing_matrix"]
-    if not matches:
-        matches = [
-            n
-            for n in leaves
-            if n["name"] == "fB" and n["path"].endswith("/feedback_loop/fB")
-        ] or [n for n in leaves if n["name"] == "fB"]
+    matches = [n for n in leaves if n["name"] == MIXING_MATRIX]
     if len(matches) != 1:
         raise ValueError(
             "FLAMO graph must contain exactly one feedback matrix leaf; "
@@ -346,11 +355,8 @@ def _feedback_leaf_module(leaves: list[dict[str, Any]]) -> Any:
 def feedback_matrix_module(model: Any) -> Any:
     """Return the live feedback-matrix module from a FLAMO FDN model.
 
-    Works for both a plain ``Series`` core and a ``Parallel`` core (an FDN summed
-    with a direct path). The module returned is the one on the recursion's
-    feedback branch; apply ``module.map(module.param)`` to read the realized
-    matrix **in-graph** -- e.g. inside a training loss, where the detaching
-    extraction path :func:`extract_build` would break gradients.
+    Apply ``module.map(module.param)`` to read the realized matrix **in-graph**
+    (e.g. inside a training loss); :func:`extract_build` detaches instead.
     """
     root = flamo_model_to_nodes(model)
     leaves = [node for node in flamo_nodes_flat(root) if node["type"] == "Leaf"]
@@ -360,13 +366,13 @@ def feedback_matrix_module(model: Any) -> Any:
 def extract_build(model: Any) -> FDNBuild:
     """Extract a complete :class:`~pyFDN.FDNBuild` from a named FLAMO model graph.
 
-    The graph must contain leaves named ``input_gain`` and ``output_gain``, plus
-    either ``mixing_matrix`` or the standard recursion feedback leaf ``fB``.
-    The delay can be named ``delay`` or be the graph's only delay module.
-    Optional attenuation (``filters``), output-filter (``post_eq``), and
-    direct-path leaves are included when present. The sample rate is read from
-    the delay module and is required: a graph that does not expose ``fs`` is
-    malformed and raises :class:`ValueError`.
+    The graph is a standard FDN as built by :func:`assemble_fdn_core`, with the
+    canonical leaf names ``input_gain``, ``output_gain``, ``delay``,
+    ``direct_gain``, ``mixing_matrix`` (the feedback matrix), and optional
+    ``filter`` (-> ``filters``) / ``output_filter`` (-> ``post_eq``). The sample
+    rate is read from the delay module and is
+    required: a graph that does not expose ``fs`` is malformed and raises
+    :class:`ValueError`.
     """
     root = flamo_model_to_nodes(model)
     leaves = [node for node in flamo_nodes_flat(root) if node["type"] == "Leaf"]
@@ -387,11 +393,7 @@ def extract_build(model: Any) -> FDNBuild:
             )
         return matches[0]["module"]
 
-    delay_matches = _named("delay")
-    if not delay_matches:
-        delay_matches = [
-            node for node in leaves if "delay" in type(node["module"]).__name__.lower()
-        ]
+    delay_matches = _named(DELAY)
     if len(delay_matches) != 1:
         raise ValueError(
             "FLAMO graph must contain exactly one delay leaf; "
@@ -401,18 +403,12 @@ def extract_build(model: Any) -> FDNBuild:
     delays = _delay_samples(delay_module)
 
     A = np.asarray(_module_value(_feedback_leaf_module(leaves)), dtype=float)
-    B = np.asarray(_module_value(_one_of("input_gain")), dtype=float)
-    C = np.asarray(_module_value(_one_of("output_gain")), dtype=float)
+    B = np.asarray(_module_value(_one_of(INPUT_GAIN)), dtype=float)
+    C = np.asarray(_module_value(_one_of(OUTPUT_GAIN)), dtype=float)
     if A.ndim != 2:
         raise ValueError("feedback matrix must be a constant two-dimensional matrix")
 
-    direct_matches = _named("direct_gain")
-    if not direct_matches:
-        direct_matches = [
-            node
-            for node in _named("brB")
-            if node["path"] in {"root/brB", "root/core/brB"}
-        ]
+    direct_matches = _named(DIRECT)
     D = (
         np.asarray(_module_value(direct_matches[0]["module"]), dtype=float)
         if len(direct_matches) == 1
@@ -420,12 +416,14 @@ def extract_build(model: Any) -> FDNBuild:
     )
 
     attenuation_sos = None
-    attenuation_matches = _named("attenuation") or _named("filter")
+    attenuation_matches = [
+        n for n in leaves if n["name"] in LOOP_FILTER_ALIASES
+    ]
     if len(attenuation_matches) == 1:
         attenuation_sos = _attenuation_to_sos(attenuation_matches[0]["module"])
 
     post_eq_sos = None
-    post_eq_matches = _named("output_filter")
+    post_eq_matches = _named(OUTPUT_FILTER)
     if len(post_eq_matches) == 1:
         post_eq_value = _module_value(post_eq_matches[0]["module"])
         if post_eq_value.ndim == 3 and post_eq_value.shape[1] == 6:

--- a/src/pyFDN/auxiliary/flamo_graph.py
+++ b/src/pyFDN/auxiliary/flamo_graph.py
@@ -266,6 +266,59 @@ def _gain_to_sos(gain: np.ndarray) -> np.ndarray:
     return sos
 
 
+def _svf_to_sos(module: Any) -> np.ndarray:
+    """Bake a flamo ``parallelSVF`` into an ``(n_sections, 6, N)`` SOS bank.
+
+    Each SVF section is a biquad whose coefficients are flamo's closed form of
+    the mapped parameters ``(f, R, mLP, mBP, mHP) = map_param2svf(param)``. The
+    section is normalized so ``a0 == 1`` (the SOS convention; ``H = B/A`` is
+    unchanged), giving a bank the render path consumes like any other.
+    """
+
+    def _np(t: Any) -> np.ndarray:
+        if hasattr(t, "detach"):
+            t = t.detach()
+        if hasattr(t, "cpu"):
+            t = t.cpu()
+        return np.asarray(t.numpy() if hasattr(t, "numpy") else t, dtype=float)
+
+    f, r, m_lp, m_bp, m_hp = (_np(t) for t in module.map_param2svf(module.param))
+    # broadcast a scalar R (lowshelf/highshelf) up to (n_sections, N)
+    f, r, m_lp, m_bp, m_hp = np.broadcast_arrays(f, r, m_lp, m_bp, m_hp)
+    sos = np.empty((*f.shape, 6), dtype=float)
+    sos[..., 0] = f**2 * m_lp + f * m_bp + m_hp
+    sos[..., 1] = 2.0 * f**2 * m_lp - 2.0 * m_hp
+    sos[..., 2] = f**2 * m_lp - f * m_bp + m_hp
+    sos[..., 3] = f**2 + 2.0 * r * f + 1.0
+    sos[..., 4] = 2.0 * f**2 - 2.0
+    sos[..., 5] = f**2 - 2.0 * r * f + 1.0
+    # (n_sections, N, 6) -> (n_sections, 6, N)
+    return np.ascontiguousarray(np.moveaxis(sos, -1, 1))
+
+
+def _attenuation_to_sos(module: Any) -> np.ndarray:
+    """In-loop filter module -> ``(n_sections, 6, N)`` SOS for ``FDNBuild.filters``.
+
+    Biquad-cascade IIR filters are baked to SOS: ``parallelSVF`` via its closed
+    form, ``parallelSOSFilter`` (and a plain broadband gain) via its value. Other
+    types -- graphic/parametric EQs and FIR -- have no SOS extractor yet and
+    raise rather than silently dropping the trained filter.
+    """
+    type_name = type(module).__name__
+    if "SVF" in type_name:
+        return _svf_to_sos(module)
+    value = _module_value(module)
+    if value.ndim == 1:
+        return _gain_to_sos(value)
+    if value.ndim == 3 and value.shape[1] == 6:
+        return np.asarray(value, dtype=float)
+    raise ValueError(
+        f"cannot extract in-loop filter of type {type_name!r} to "
+        "FDNBuild.filters; only biquad-cascade IIR filters (parallelSVF, "
+        "parallelSOSFilter) are supported"
+    )
+
+
 def _feedback_leaf_module(leaves: list[dict[str, Any]]) -> Any:
     """The single feedback-matrix leaf module from a flat leaf list.
 
@@ -369,12 +422,7 @@ def extract_build(model: Any) -> FDNBuild:
     attenuation_sos = None
     attenuation_matches = _named("attenuation") or _named("filter")
     if len(attenuation_matches) == 1:
-        attenuation_module = attenuation_matches[0]["module"]
-        attenuation_value = _module_value(attenuation_module)
-        if attenuation_value.ndim == 1:
-            attenuation_sos = _gain_to_sos(attenuation_value)
-        elif attenuation_value.ndim == 3 and attenuation_value.shape[1] == 6:
-            attenuation_sos = np.asarray(attenuation_value, dtype=float)
+        attenuation_sos = _attenuation_to_sos(attenuation_matches[0]["module"])
 
     post_eq_sos = None
     post_eq_matches = _named("output_filter")

--- a/src/pyFDN/generate/fdn_matrix_gallery.py
+++ b/src/pyFDN/generate/fdn_matrix_gallery.py
@@ -24,21 +24,22 @@ class FDNSystem(NamedTuple):
     D: np.ndarray
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class FDNBuild:
     """Complete FDN parameters returned by :func:`fdn_build_gallery`.
 
-    ``filters`` is either ``None`` (lossless) or a per-delay first-order
-    absorption SOS bank with shape ``(num_sections, 6, N)`` suitable for
-    ``dss_to_flamo(..., sos_filter=...)``. ``post_eq`` is an optional per-output
-    SOS bank with shape ``(num_sections, 6, num_outputs)`` suitable for the
-    ``output_filter`` argument of :func:`pyFDN.dss_to_flamo`.
+    ``D`` is the direct gain, or ``None`` for a zero ``(num_outputs, num_inputs)``
+    direct path. ``filters`` is either ``None`` (lossless) or a per-delay
+    first-order absorption SOS bank with shape ``(num_sections, 6, N)`` suitable
+    for ``dss_to_flamo(..., sos_filter=...)``. ``post_eq`` is an optional
+    per-output SOS bank with shape ``(num_sections, 6, num_outputs)`` suitable for
+    the ``output_filter`` argument of :func:`pyFDN.dss_to_flamo`.
     """
 
     A: np.ndarray
     B: np.ndarray
     C: np.ndarray
-    D: np.ndarray
+    D: np.ndarray | None = None
     delays: np.ndarray
     fs: float
     filters: np.ndarray | None = None
@@ -295,7 +296,16 @@ def fdn_build_gallery(
     post_eq = _build_post_eq(
         num_outputs, float(fs), post_eq_db_dc, post_eq_db_nyquist, post_eq_crossover
     )
-    return FDNBuild(A, B, C, D, delays_array, float(fs), filters, post_eq)
+    return FDNBuild(
+        A=A,
+        B=B,
+        C=C,
+        D=D,
+        delays=delays_array,
+        fs=float(fs),
+        filters=filters,
+        post_eq=post_eq,
+    )
 
 
 @overload

--- a/src/pyFDN/train/build.py
+++ b/src/pyFDN/train/build.py
@@ -9,6 +9,7 @@ trainable flamo ``Shell`` you can render, train, and extract.
 from __future__ import annotations
 
 import dataclasses
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -43,6 +44,7 @@ def build_fdn(
     output_gain: np.ndarray | None = None,
     direct: float | np.ndarray = 0.0,
     trainable: Trainable | None = None,
+    loop_filter: Any | None = None,
     fs: float = 48000.0,
     nfft: int = 2**14,
     output: str = "time",
@@ -71,6 +73,13 @@ def build_fdn(
         Direct path ``D``; a scalar fills ``(n_out, n_in)``.
     trainable : Trainable, optional
         Trainable parameter groups (default :class:`Trainable`).
+    loop_filter : flamo dsp module, optional
+        A prebuilt flamo filter module to use as the in-loop attenuation filter
+        (its own ``requires_grad`` governs trainability). Must match the build:
+        ``loop_filter.param.shape[-1] == N`` and ``loop_filter.nfft == nfft``.
+        When given it overrides ``rt`` / sampled absorption for the loop slot;
+        pass ``rt=None`` to silence the override warning. See
+        :func:`trainable_from_build`.
     fs, nfft, output, device, dtype : see :func:`trainable_from_build`.
     rng : np.random.Generator, int, or None
         Seed for the sampled delays / default feedback matrix.
@@ -118,8 +127,17 @@ def build_fdn(
     n_out, n_in = c.shape[0], b.shape[1]
     d = _resolve_direct(direct, n_out, n_in)
 
+    # A prebuilt loop_filter fully defines the in-loop absorption, so the
+    # rt-derived bank is skipped (and ignored if rt was set).
+    if loop_filter is not None and rt is not None:
+        warnings.warn(
+            f"loop_filter provided; rt={rt!r} is ignored for the in-loop filter "
+            "(pass rt=None to silence)",
+            stacklevel=2,
+        )
+
     filters = None
-    if rt is not None:
+    if rt is not None and loop_filter is None:
         from pyFDN.auxiliary.acoustics import first_order_absorption
 
         rt_dc, rt_ny = _rt_pair(rt)
@@ -138,6 +156,7 @@ def build_fdn(
     return trainable_from_build(
         build,
         trainable=trainable,
+        loop_filter=loop_filter,
         matrix=matrix,
         nfft=nfft,
         output=output,
@@ -150,6 +169,7 @@ def trainable_from_build(
     build: FDNBuild,
     *,
     trainable: Trainable | None = None,
+    loop_filter: Any | None = None,
     matrix: MatrixParam = "orthogonal",
     nfft: int = 2**14,
     output: str = "time",
@@ -165,6 +185,14 @@ def trainable_from_build(
         ``filters``/``post_eq``).
     trainable : Trainable, optional
         Trainable parameter groups (default :class:`Trainable`).
+    loop_filter : flamo dsp module, optional
+        A prebuilt flamo filter module placed in the in-loop attenuation slot.
+        Trainability comes from the module's own ``requires_grad`` (there is no
+        ``Trainable`` flag for it). Must satisfy ``loop_filter.param.shape[-1]``
+        ``== N`` (the number of delay lines) and ``loop_filter.nfft == nfft``.
+        When given it overrides ``build.filters`` for the loop slot;
+        :func:`pyFDN.extract_build` bakes a trained ``parallelSVF`` /
+        ``parallelSOSFilter`` back to ``FDNBuild.filters`` (other types raise).
     matrix : {"orthogonal", "random"}
         Feedback-matrix parametrization.
     nfft : int
@@ -220,17 +248,25 @@ def trainable_from_build(
         np.asarray(build.delays, dtype=np.float64).ravel(), fs, nfft, device, dtype
     )
 
-    # In-loop absorption (decay) is a frozen build property.
-    loop_filter = (
-        sos_filter_module(
+    # In-loop absorption (decay). A prebuilt loop_filter module (its own
+    # requires_grad governs trainability) takes precedence; otherwise the
+    # build's SOS bank is wired frozen.
+    n = int(np.asarray(build.delays).ravel().size)
+    if loop_filter is not None:
+        loop_filter_module = _validated_loop_filter(loop_filter, n, nfft)
+        if build.filters is not None:
+            warnings.warn(
+                "loop_filter provided; build.filters is ignored", stacklevel=2
+            )
+    elif build.filters is not None:
+        loop_filter_module = sos_filter_module(
             np.asarray(build.filters, dtype=np.float64),
             nfft,
             device=device,
             dtype=dtype,
         )
-        if build.filters is not None
-        else None
-    )
+    else:
+        loop_filter_module = None
     output_filter = (
         sos_filter_module(
             np.asarray(build.post_eq, dtype=np.float64),
@@ -249,7 +285,7 @@ def trainable_from_build(
         delays=delays,
         output_gain=output_gain,
         direct=direct_gain,
-        loop_filter=loop_filter,
+        loop_filter=loop_filter_module,
         output_filter=output_filter,
     )
     return wrap_fdn_shell(core, nfft=nfft, dtype=dtype, output=output)
@@ -274,6 +310,29 @@ def build_set_decay(
         rt_dc, rt_ny, np.asarray(build.delays), float(build.fs), rt_crossover
     )
     return dataclasses.replace(build, filters=filters)
+
+
+def _validated_loop_filter(loop_filter: Any, n: int, nfft: int) -> Any:
+    """Return ``loop_filter`` after checking it matches the FDN shape.
+
+    A prebuilt flamo module bakes in its channel count and ``nfft``, so both
+    must line up with the build (``N`` delay lines, FFT size ``nfft``) for the
+    in-loop wiring to be valid. The channel count is the last parameter
+    dimension (flamo's ``.size`` is the full param shape, not ``(N,)``).
+    """
+    param = getattr(loop_filter, "param", None)
+    n_ch = int(param.shape[-1]) if param is not None else None
+    if n_ch != n:
+        raise ValueError(
+            f"loop_filter operates on {n_ch} channels but the FDN has {n} "
+            "delay lines"
+        )
+    lf_nfft = getattr(loop_filter, "nfft", None)
+    if lf_nfft is None or int(lf_nfft) != int(nfft):
+        raise ValueError(
+            f"loop_filter nfft={lf_nfft} must match the build nfft={nfft}"
+        )
+    return loop_filter
 
 
 def _rt_pair(rt: float | tuple[float, float]) -> tuple[float, float]:

--- a/src/pyFDN/train/build.py
+++ b/src/pyFDN/train/build.py
@@ -111,9 +111,7 @@ def build_fdn(
     else:
         a = _random_so_n(n, local_rng)
 
-    # Default IO is "normalized" (ones / sqrt(N)): puts the initial |H| near unity
-    # so a colorless objective starts well-conditioned. Override with input_gain/
-    # output_gain for other layouts.
+    # Default IO is ones / sqrt(N); override with input_gain / output_gain.
     b = (
         np.ones((n, 1)) / np.sqrt(n)
         if input_gain is None
@@ -127,8 +125,6 @@ def build_fdn(
     n_out, n_in = c.shape[0], b.shape[1]
     d = _resolve_direct(direct, n_out, n_in)
 
-    # A prebuilt loop_filter fully defines the in-loop absorption, so the
-    # rt-derived bank is skipped (and ignored if rt was set).
     if loop_filter is not None and rt is not None:
         warnings.warn(
             f"loop_filter provided; rt={rt!r} is ignored for the in-loop filter "
@@ -239,8 +235,6 @@ def trainable_from_build(
         dtype=dtype,
         requires_grad=trainable.feedback,
     )
-    # Direct path is ALWAYS wired (zero by default) so the same model serves any
-    # objective; the core is therefore a Parallel.
     direct_gain = gain_module(
         d, nfft, device=device, dtype=dtype, requires_grad=trainable.direct
     )
@@ -248,9 +242,7 @@ def trainable_from_build(
         np.asarray(build.delays, dtype=np.float64).ravel(), fs, nfft, device, dtype
     )
 
-    # In-loop absorption (decay). A prebuilt loop_filter module (its own
-    # requires_grad governs trainability) takes precedence; otherwise the
-    # build's SOS bank is wired frozen.
+    # A prebuilt loop_filter takes precedence over the build's SOS bank.
     n = int(np.asarray(build.delays).ravel().size)
     if loop_filter is not None:
         loop_filter_module = _validated_loop_filter(loop_filter, n, nfft)
@@ -313,13 +305,8 @@ def build_set_decay(
 
 
 def _validated_loop_filter(loop_filter: Any, n: int, nfft: int) -> Any:
-    """Return ``loop_filter`` after checking it matches the FDN shape.
-
-    A prebuilt flamo module bakes in its channel count and ``nfft``, so both
-    must line up with the build (``N`` delay lines, FFT size ``nfft``) for the
-    in-loop wiring to be valid. The channel count is the last parameter
-    dimension (flamo's ``.size`` is the full param shape, not ``(N,)``).
-    """
+    """Return ``loop_filter`` after checking its channel count and ``nfft`` match
+    the FDN (``N`` delay lines, FFT size ``nfft``)."""
     param = getattr(loop_filter, "param", None)
     n_ch = int(param.shape[-1]) if param is not None else None
     if n_ch != n:

--- a/src/pyFDN/train/engine.py
+++ b/src/pyFDN/train/engine.py
@@ -126,11 +126,9 @@ def train_fdn(
         device=dev,
         dtype=torch_dtype,
     )
-    # Set the Shell's output layer to match the objective (time iFFT / magnitude
-    # |.|); a deliberate, visible mutation of the model.
+    # Set the Shell's output layer to match the objective (mutates the model).
     model.set_outputLayer(output_layer(output_domain, nfft, torch_dtype))
 
-    # Checkpoint only when logging to a directory; EagerTrainer asserts it exists.
     save_checkpoints = log and train_dir is not None
     if save_checkpoints:
         assert train_dir is not None  # implied by save_checkpoints
@@ -163,12 +161,15 @@ def train_fdn(
 
 def _loop_filter_is_trainable(model: Any) -> bool:
     """True if the model's in-loop filter leaf has any ``requires_grad`` param."""
+    from pyFDN.auxiliary import flamo_graph as layout
     from pyFDN.auxiliary.flamo_graph import flamo_model_to_nodes, flamo_nodes_flat
 
     leaves = [
         n for n in flamo_nodes_flat(flamo_model_to_nodes(model)) if n["type"] == "Leaf"
     ]
-    modules = [n["module"] for n in leaves if n["name"] in ("filter", "attenuation")]
+    modules = [
+        n["module"] for n in leaves if n["name"] in layout.LOOP_FILTER_ALIASES
+    ]
     return any(
         getattr(p, "requires_grad", False)
         for m in modules
@@ -179,6 +180,7 @@ def _loop_filter_is_trainable(model: Any) -> bool:
 
 def _model_info(model: Any) -> tuple[int, int, float]:
     """``(n_in, n_out, fs)`` read from the model's gain and delay modules."""
+    from pyFDN.auxiliary import flamo_graph as layout
     from pyFDN.auxiliary.flamo_graph import flamo_model_to_nodes, flamo_nodes_flat
 
     leaves = [
@@ -193,15 +195,12 @@ def _model_info(model: Any) -> tuple[int, int, float]:
             )
         return matches[0]
 
-    delay = next(
-        (n["module"] for n in leaves if "delay" in type(n["module"]).__name__.lower()),
-        None,
-    )
+    delay = next((n["module"] for n in leaves if n["name"] == layout.DELAY), None)
     if delay is None:
         raise ValueError("model has no delay module; check build again.")
     fs = float(delay.fs)
     return (
-        int(_gain("input_gain").param.shape[1]),
-        int(_gain("output_gain").param.shape[0]),
+        int(_gain(layout.INPUT_GAIN).param.shape[1]),
+        int(_gain(layout.OUTPUT_GAIN).param.shape[0]),
         fs,
     )

--- a/src/pyFDN/train/engine.py
+++ b/src/pyFDN/train/engine.py
@@ -8,6 +8,7 @@ returns a :class:`TrainLog`. Read the result back with :func:`pyFDN.extract_buil
 from __future__ import annotations
 
 import os
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -104,6 +105,14 @@ def train_fdn(
     nfft = int(model.get_inputLayer().nfft)
     n_in, n_out, fs = _model_info(model)
 
+    if mode == "colorless" and _loop_filter_is_trainable(model):
+        warnings.warn(
+            "colorless does not constrain decay, so a trainable in-loop filter "
+            "is unconstrained and may drift toward a lossless/unstable loop; use "
+            "match_spectrogram / match_mel_spectrogram to fit a target's decay.",
+            stacklevel=2,
+        )
+
     inp, tgt, criteria, output_domain = build_objective(
         mode,
         target=target,
@@ -149,6 +158,22 @@ def train_fdn(
         loss_log={k: [float(x) for x in v] for k, v in history.items() if k != "total"},
         steps_run=steps_run,
         stopped_early=steps_run < max_steps,
+    )
+
+
+def _loop_filter_is_trainable(model: Any) -> bool:
+    """True if the model's in-loop filter leaf has any ``requires_grad`` param."""
+    from pyFDN.auxiliary.flamo_graph import flamo_model_to_nodes, flamo_nodes_flat
+
+    leaves = [
+        n for n in flamo_nodes_flat(flamo_model_to_nodes(model)) if n["type"] == "Leaf"
+    ]
+    modules = [n["module"] for n in leaves if n["name"] in ("filter", "attenuation")]
+    return any(
+        getattr(p, "requires_grad", False)
+        for m in modules
+        if hasattr(m, "parameters")
+        for p in m.parameters()
     )
 
 

--- a/src/pyFDN/translate/dss_to_flamo.py
+++ b/src/pyFDN/translate/dss_to_flamo.py
@@ -28,7 +28,7 @@ def dss_to_flamo(
     A: np.ndarray,
     B: np.ndarray,
     C: np.ndarray,
-    D: np.ndarray,
+    D: np.ndarray | None,
     m: np.ndarray,
     Fs: float,
     nfft: int = 2**16,
@@ -55,8 +55,8 @@ def dss_to_flamo(
         Input gain.
     C : (num_out, N) array
         Output gain.
-    D : (num_out, num_in) array
-        Direct gain.
+    D : (num_out, num_in) array or None
+        Direct gain. ``None`` resolves to a zero ``(num_out, num_in)`` gain.
     m : (N,) array
         Delay lengths in samples (one per delay line).
     Fs : float
@@ -104,7 +104,11 @@ def dss_to_flamo(
     A = np.asarray(A, dtype=np.float64)
     B = np.asarray(B, dtype=np.float64)
     C = np.asarray(C, dtype=np.float64)
-    D = np.asarray(D, dtype=np.float64)
+    D = (
+        np.zeros((C.shape[0], B.shape[1]), dtype=np.float64)
+        if D is None
+        else np.asarray(D, dtype=np.float64)
+    )
     m = np.asarray(m, dtype=np.float64).ravel()
     N = A.shape[0]
     if m.shape[0] != N:

--- a/tests/test_auxiliary_delay.py
+++ b/tests/test_auxiliary_delay.py
@@ -69,7 +69,7 @@ def test_flamo_delay_feedback_matrix_copies_and_rewires_model():
     assert hasattr(result_loop.feedback, "delay_out")
 
     for module, samples in (
-        (result_loop.feedforward, [5, 7]),
+        (result_loop.feedforward.delay, [5, 7]),
         (result_loop.feedback.delay_in, [1, 2]),
         (result_loop.feedback.delay_out, [3, 4]),
     ):

--- a/tests/test_auxiliary_flamo.py
+++ b/tests/test_auxiliary_flamo.py
@@ -91,23 +91,71 @@ def test_dss_to_flamo_roundtrips_through_extractor():
     np.testing.assert_array_equal(params.delays, m.astype(int))
 
 
-def test_assemble_fdn_core_direct_toggles_parallel():
+def _leaf_names(model):
+    from pyFDN.auxiliary.flamo_graph import flamo_model_to_nodes, flamo_nodes_flat
+
+    return {
+        node["name"]
+        for node in flamo_nodes_flat(flamo_model_to_nodes(model))
+        if node["type"] == "Leaf"
+    }
+
+
+def _assemble_kw(nfft):
     n, a, b, c, d, m = _small_fdn()
-    nfft = 2**11
-    kw = {
+    return {
         "input_gain": gain_module(b, nfft, device="cpu"),
         "feedback": gain_module(a, nfft, device="cpu"),
         "delays": delay_module(m / 48000.0, nfft, Fs=48000, device="cpu"),
         "output_gain": gain_module(c, nfft, device="cpu"),
     }
-    # No direct path -> plain Series core whose feedback matrix stays reachable
-    # at core.feedback_loop.feedback (required by flamo's sparsity_loss).
-    series_core = assemble_fdn_core(direct=None, **kw)
-    assert type(series_core).__name__ == "Series"
-    assert hasattr(series_core.feedback_loop, "feedback")
-    # Direct path -> Parallel(brA=fdn, brB=direct).
-    parallel_core = assemble_fdn_core(direct=gain_module(d, nfft, device="cpu"), **kw)
-    assert type(parallel_core).__name__ == "Parallel"
+
+
+def test_assemble_fdn_core_always_parallel():
+    nfft = 2**11
+    d = np.zeros((1, 1))
+    core = assemble_fdn_core(direct=gain_module(d, nfft, device="cpu"), **_assemble_kw(nfft))
+    assert type(core).__name__ == "Parallel"
+
+
+def test_assemble_fdn_core_requires_direct():
+    nfft = 2**11
+    with pytest.raises(TypeError):
+        assemble_fdn_core(**_assemble_kw(nfft))
+
+
+def test_dss_to_flamo_names_delay_and_direct_leaves():
+    n, a, b, c, d, m = _small_fdn()
+    model = dss_to_flamo(a, b, c, d, m, Fs=48000, nfft=2**11, device="cpu")
+    names = _leaf_names(model)
+    assert {"input_gain", "output_gain", "delay", "direct_gain"} <= names
+
+
+def test_dss_to_flamo_direct_none_defaults_to_zeros():
+    n, a, b, c, d, m = _small_fdn()
+    model = dss_to_flamo(a, b, c, None, m, Fs=48000, nfft=2**11, device="cpu")
+    params = extract_build(model)
+    assert params.D.shape == (1, 1)
+    np.testing.assert_allclose(params.D, 0.0, atol=1e-6)
+
+
+def test_feedback_leaf_is_mixing_matrix():
+    n, a, b, c, d, m = _small_fdn()
+    model = dss_to_flamo(a, b, c, d, m, Fs=48000, nfft=2**11, device="cpu")
+    assert "mixing_matrix" in _leaf_names(model)
+    np.testing.assert_allclose(extract_build(model).A, a, atol=1e-5)
+
+
+def test_graph_branch_labels_are_descriptive():
+    from pyFDN.auxiliary.flamo_graph import flamo_model_to_nodes, flamo_nodes_flat
+
+    n, a, b, c, d, m = _small_fdn()
+    model = dss_to_flamo(a, b, c, d, m, Fs=48000, nfft=2**11, device="cpu")
+    paths = "\n".join(
+        node["path"] for node in flamo_nodes_flat(flamo_model_to_nodes(model))
+    )
+    for seg in ("/fdn/", "/direct/", "/feedforward/", "/feedback/"):
+        assert seg in paths, seg
 
 
 def test_wrap_fdn_shell_output_modes():
@@ -118,6 +166,7 @@ def test_wrap_fdn_shell_output_modes():
         feedback=gain_module(a, nfft, device="cpu"),
         delays=delay_module(m / 48000.0, nfft, Fs=48000, device="cpu"),
         output_gain=gain_module(c, nfft, device="cpu"),
+        direct=gain_module(d, nfft, device="cpu"),
     )
     impulse = torch.zeros(1, nfft, 1)
     impulse[:, 0, :] = 1.0

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -250,6 +250,118 @@ def test_mimo_target_wrong_shape_raises():
         train_fdn(model, "match_spectrogram", target=bad, max_steps=2, **_FAST)
 
 
+# --- trainable in-loop filter (prebuilt module) ----------------------------
+
+
+def _svf(N, nfft, *, n_sections=1, filter_type=None, requires_grad=True):
+    from flamo.processor import dsp
+
+    return dsp.parallelSVF(
+        size=(N,),
+        n_sections=n_sections,
+        filter_type=filter_type,
+        nfft=nfft,
+        fs=48000,
+        requires_grad=requires_grad,
+    )
+
+
+def test_loop_filter_module_is_wired_and_keeps_requires_grad():
+    nfft = 2**10
+    svf = _svf(4, nfft, requires_grad=True)
+    model = build_fdn(N=4, rt=None, nfft=nfft, loop_filter=svf, device="cpu", rng=0)
+    # the exact module is placed in the in-loop "filter" slot, grad preserved
+    assert _leaf(model, "filter") is svf
+    assert svf.param.requires_grad is True
+
+
+def test_loop_filter_wrong_channel_count_raises():
+    nfft = 2**10
+    svf = _svf(3, nfft)  # 3 channels, model has 4 delay lines
+    with pytest.raises(ValueError, match="loop_filter"):
+        build_fdn(N=4, rt=None, nfft=nfft, loop_filter=svf, device="cpu", rng=0)
+
+
+def test_loop_filter_wrong_nfft_raises():
+    svf = _svf(4, 256)  # nfft 256 != build nfft 1024
+    with pytest.raises(ValueError, match="nfft"):
+        build_fdn(N=4, rt=None, nfft=2**10, loop_filter=svf, device="cpu", rng=0)
+
+
+def test_rt_and_loop_filter_together_warns_rt_ignored():
+    nfft = 2**10
+    svf = _svf(4, nfft)
+    with pytest.warns(UserWarning, match="ignored"):
+        build_fdn(N=4, rt=2.0, nfft=nfft, loop_filter=svf, device="cpu", rng=0)
+
+
+def test_loop_filter_with_rt_none_does_not_warn():
+    import warnings
+
+    nfft = 2**10
+    svf = _svf(4, nfft)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        build_fdn(N=4, rt=None, nfft=nfft, loop_filter=svf, device="cpu", rng=0)
+
+
+def test_extract_svf_loop_filter_roundtrips_to_sos():
+    from pyFDN.auxiliary.flamo import flamo_freq_response
+
+    nfft = 2**11
+    svf = _svf(4, nfft, n_sections=2, filter_type="lowpass")
+    model = build_fdn(N=4, rt=None, nfft=nfft, loop_filter=svf, device="cpu", rng=0)
+
+    b = pyFDN.extract_build(model)
+    assert b.filters is not None and b.filters.shape == (2, 6, 4)
+
+    # rebuilding from the baked SOS reproduces the SVF-FDN's frequency response
+    twin = pyFDN.build_to_flamo(b, nfft=nfft, device="cpu")
+    h_svf = np.abs(np.asarray(flamo_freq_response(model, fs=48000)).reshape(-1))
+    h_sos = np.abs(np.asarray(flamo_freq_response(twin, fs=48000)).reshape(-1))
+    np.testing.assert_allclose(h_sos, h_svf, rtol=1e-3, atol=1e-4)
+
+
+def test_extract_postponed_filter_type_raises():
+    from flamo.processor import dsp
+
+    nfft = 2**10
+    geq = dsp.parallelGEQ(size=(4,), nfft=nfft, fs=48000, requires_grad=True)
+    model = build_fdn(N=4, rt=None, nfft=nfft, loop_filter=geq, device="cpu", rng=0)
+    with pytest.raises(ValueError, match="biquad-cascade"):
+        pyFDN.extract_build(model)
+
+
+def test_match_spectrogram_trains_loop_filter():
+    nfft = 2**11
+    target = build_fdn(N=4, rt=0.1, nfft=nfft, device="cpu", rng=7)
+    target_ir = np.asarray(pyFDN.flamo_time_response(target, fs=48000)).reshape(-1)
+
+    svf = _svf(4, nfft, n_sections=2, filter_type="lowpass")
+    fresh = build_fdn(N=4, rt=None, nfft=nfft, loop_filter=svf, device="cpu", rng=11)
+    log = train_fdn(
+        fresh,
+        "match_spectrogram",
+        target=target_ir,
+        mss_nfft=(256, 512),
+        max_steps=5,
+        rng=0,
+        **_FAST,
+    )
+    # gradients reach the trainable filter and the objective is computable
+    # (multi-step loop stability is the caller's responsibility, by design)
+    assert svf.param.grad is not None
+    assert np.isfinite(log.train_loss[0])
+
+
+def test_colorless_with_trainable_loop_filter_warns():
+    nfft = 2**10
+    svf = _svf(4, nfft, filter_type="lowpass")
+    model = build_fdn(N=4, rt=None, nfft=nfft, loop_filter=svf, device="cpu", rng=0)
+    with pytest.warns(UserWarning, match="colorless"):
+        train_fdn(model, "colorless", max_steps=2, rng=0, **_FAST)
+
+
 # --- analytic decay (the exact RT path) ------------------------------------
 
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -250,6 +250,42 @@ def test_mimo_target_wrong_shape_raises():
         train_fdn(model, "match_spectrogram", target=bad, max_steps=2, **_FAST)
 
 
+# --- unified structure + canonical names -----------------------------------
+
+
+def test_direct_gain_leaf_named_and_default_zeros_not_trainable():
+    model = build_fdn(N=4, rt=None, nfft=2**10, device="cpu", rng=0)
+    direct = _leaf(model, "direct_gain")  # stable name (was the unnamed brB)
+    assert direct.param.requires_grad is False
+    np.testing.assert_allclose(np.asarray(direct.param.detach()), 0.0, atol=1e-6)
+
+
+def test_delay_leaf_named_delay_with_and_without_loop_filter():
+    from flamo.processor import dsp
+
+    nfft = 2**10
+    plain = build_fdn(N=4, rt=None, nfft=nfft, device="cpu", rng=0)
+    _leaf(plain, "delay")  # raises if absent
+
+    svf = dsp.parallelSVF(size=(4,), nfft=nfft, fs=48000, requires_grad=True)
+    withf = build_fdn(N=4, rt=None, nfft=nfft, loop_filter=svf, device="cpu", rng=0)
+    _leaf(withf, "delay")
+    assert _leaf(withf, "filter") is svf
+
+
+def test_fdnbuild_direct_none_roundtrips_to_zeros():
+    import dataclasses
+
+    build = pyFDN.extract_build(
+        build_fdn(N=4, rt=None, nfft=2**10, device="cpu", rng=0)
+    )
+    build = dataclasses.replace(build, D=None)
+    model = pyFDN.build_to_flamo(build, nfft=2**10, device="cpu")
+    out = pyFDN.extract_build(model)
+    assert out.D.shape == (1, 1)
+    np.testing.assert_allclose(out.D, 0.0, atol=1e-6)
+
+
 # --- trainable in-loop filter (prebuilt module) ----------------------------
 
 
@@ -314,6 +350,8 @@ def test_extract_svf_loop_filter_roundtrips_to_sos():
 
     b = pyFDN.extract_build(model)
     assert b.filters is not None and b.filters.shape == (2, 6, 4)
+    # SOS is normalized (a0 == 1), matching the rest of the codebase / scipy
+    np.testing.assert_allclose(b.filters[:, 3, :], 1.0, atol=1e-12)
 
     # rebuilding from the baked SOS reproduces the SVF-FDN's frequency response
     twin = pyFDN.build_to_flamo(b, nfft=nfft, device="cpu")


### PR DESCRIPTION
Enhance FLAMO module with prebuilt in-loop filter support and refactor training setup.

Fixes #200.

**2026-08-23: This PR is closed for outdated development.**


## Changes

- Added support for prebuilt in-loop filter module in `build_fdn` and `train_fdn` functions.

- Refactored FLAMO module integration and improved filter training setup.

- Updated tests for FLAMO and training API.
