### PR TITLE
Release v0.3.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,26 @@
 History
 =======
 
+0.3.0 (2026-08-17)
+------------------
+
+* **Breaking:** replace the ``pyFDN.dsp`` subpackage with ``pyFDN.td``. The
+  top-level ``FeedbackDelay``, ``FIRMatrixFilter`` and ``SOSFilterBank``
+  exports are gone; use ``pyFDN.td`` operators instead.
+* **Breaking:** ship the packaged colorless-FDN presets as JSON rather than
+  MATLAB ``.mat`` files.
+* Add ``pyFDN.td``, a time-domain block-based processing graph built on NumPy
+  alone (no torch, no FFT), with the ``Series``, ``Parallel`` and
+  ``Recursion`` connectors and stateful ``Gain``, ``Delay``, ``SOSBank``,
+  ``MatrixFIR``, ``MatrixConvolver`` and ``TimeVaryingMatrix`` operators.
+* Add ``load_fdn_build``, ``save_fdn_build``, ``fdn_build_from_dict`` and
+  ``fdn_build_to_dict`` for reading and writing FDN builds as JSON.
+* Add an FDN-to-FAUST example that compiles a pyFDN design with adac, and a
+  reverberation-enhancement example.
+* Improve the example gallery and stop tracking generated documentation in the
+  repository.
+* Test on Python 3.14 in CI and the documentation build.
+
 0.2.0 (2026-08-10)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyFDN"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python library for Feedback Delay Networks"
 readme = "README.rst"
 authors = [
@@ -113,7 +113,7 @@ include = ["pyFDN*"]
 # triggers on. Usage: bump-my-version bump {major|minor|patch}
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.3.0"
 allow_dirty = false
 commit = true
 message = "Bump version: {current_version} → {new_version}"

--- a/src/pyFDN/__init__.py
+++ b/src/pyFDN/__init__.py
@@ -3,7 +3,7 @@
 from importlib import import_module
 
 __author__ = "Facundo Franchino"
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     # acoustics


### PR DESCRIPTION
Bumps the version to 0.3.0 and adds the changelog entry for the release.

Merging this does **not** publish anything. After merge, tagging the merged commit `v0.3.0` and pushing the tag triggers `.github/workflows/release.yml`, which builds, publishes to TestPyPI automatically, then waits for manual approval on the `pypi` environment.

## Changes since v0.2.0

Two breaking changes in this release:

- `pyFDN.dsp` is removed and replaced by `pyFDN.td`. The top-level `FeedbackDelay`, `FIRMatrixFilter` and `SOSFilterBank` exports are gone.
- Packaged colorless-FDN presets ship as JSON instead of MATLAB `.mat` files.

Plus the new `pyFDN.td` time-domain graph engine, JSON build I/O helpers, the FDN-to-FAUST and reverberation-enhancement examples, gallery cleanup, and Python 3.14 in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)