### PR TITLE
Fix RST underline length in README "Helpful links" heading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ and ``tox.ini`` for multi-environment testing.
 
 
 Helpful links
------------
+-------------
 
 * `List of papers on Feedback Delay Networks <https://github.com/gdalsanto/delay-network-reverbs>`_ .
 * `Multislope Estimation library <https://github.com/artificial-audio/multislope>`_ .


### PR DESCRIPTION
Unblocks the v0.3.0 release.

The `Helpful links` heading in `README.rst` had an 11-character underline under a 13-character title. docutils reports `Title underline too short`, and since `README.rst` is the project's `long_description`, `twine check` treats it as a syntax error and fails:

```
Checking dist/pyfdn-0.3.0-py3-none-any.whl: FAILED
ERROR  `long_description` has syntax errors in markup and would not be rendered on PyPI.
       line 110: Warning: Title underline too short.
```

That failed the `Build distribution` job of the v0.3.0 release run, before any upload — nothing reached TestPyPI or PyPI.

Verified locally after the fix:

```
Checking dist/pyfdn-0.3.0-py3-none-any.whl: PASSED
Checking dist/pyfdn-0.3.0.tar.gz: PASSED
```

Note this class of error is invisible to CI today — `twine check` only runs in `release.yml`, so it cannot surface until a tag is pushed. Adding a `python -m build && twine check dist/*` step to `ci.yml` would catch it on PRs instead; happy to do that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)