### PR TITLE
Check packaging metadata in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,31 @@ jobs:
         path: coverage.xml
         retention-days: 7
 
+  # Mirrors the build step of .github/workflows/release.yml so packaging
+  # metadata errors surface on pull requests instead of on a pushed tag, where
+  # the only fix is to move the tag. README.rst is the PyPI long_description,
+  # so a malformed heading in it fails twine check and blocks the release.
+  # Keep the Python version in sync with release.yml.
+  packaging:
+    runs-on: ubuntu-latest
+    env:
+      PIP_NO_CACHE_DIR: 1
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Build sdist and wheel
+      run: |
+        python -m pip install --upgrade pip --no-cache-dir
+        pip install --no-cache-dir build twine
+        python -m build
+        twine check dist/*
+
   # Guards the runtime dependency boundary: the library itself must work with
   # only its mandatory dependencies installed. Decay estimation beyond a single
   # slope (multislope/DecayFitNet) and the plotting stack belong to the example


### PR DESCRIPTION
Follow-up to #214, which fixed the README heading that broke the v0.3.0 release build. This stops the same class of error from reaching a tag again.

## Problem

`twine check` only ran in `release.yml`, which triggers on a pushed tag. So packaging metadata was never validated on a pull request: #213 went green across all four checks, and the failure only appeared after `v0.3.0` was pushed — the point where recovery means deleting and moving a tag.

`README.rst` is the project's `long_description` (`pyproject.toml:9`), so any RST error in it fails `twine check` and blocks the release, even though the wheel and sdist build fine.

## Change

A `packaging` job mirroring the build step of `release.yml`:

```yaml
python -m build
twine check dist/*
```

Runs on 3.11 to match `release.yml`; there's a comment on the job to keep the two in sync. Roughly 15s, and independent of the other jobs so a metadata error reports as its own check rather than being buried in a test job.

## Verification

Reintroduced the original bug locally and confirmed the job's commands catch it:

```
Checking dist/pyfdn-0.3.0-py3-none-any.whl: FAILED
         line 110: Warning: Title underline too short.
Checking dist/pyfdn-0.3.0.tar.gz: FAILED
```

Then restored and confirmed current `main` passes:

```
Checking dist/pyfdn-0.3.0-py3-none-any.whl: PASSED
Checking dist/pyfdn-0.3.0.tar.gz: PASSED
```

Note this job is not in the required status checks for `main`; add it there if it should block merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)