### PR TITLE
Fail the docs build on notebook cell errors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'src/**'
       - 'docs/**'
+      # The marimo notebooks under examples/ are executed and baked into the
+      # site at build time, so editing one changes the published docs.
+      - 'examples/**'
       - '.github/workflows/docs.yml'
   pull_request:
     branches: [ main ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,6 +148,17 @@ marimo_cache_notebooks = False
 #
 # This patch lives in conf.py (our repo), so the installed sphinx-marimo package
 # stays pristine and deployment (RTD / GitHub Actions) needs no vendored changes.
+#
+# Cell errors are build failures: a notebook that raises still produces HTML,
+# with the traceback baked in where the output should be, so a broken example
+# reaches the published site looking like a rendered page. We record every
+# notebook whose export exited non-zero and fail the build at the end (see
+# ``setup`` below) instead of aborting on the first one, so a single run reports
+# all of them. Set ``PYFDN_DOCS_ALLOW_NOTEBOOK_ERRORS=1`` to downgrade this back
+# to a warning when you need a build out of a knowingly broken notebook.
+_marimo_export_failures: "list[tuple[str, str]]" = []
+
+
 def _patch_marimo_static_export():
     import subprocess
 
@@ -173,8 +184,8 @@ def _patch_marimo_static_export():
         # `html` (not `html-wasm`) executes the notebook server-side with the real
         # venv and embeds the outputs. marimo returns a non-zero exit code when any
         # cell raises during execution, but it still writes the HTML (with the error
-        # baked in), so we log a warning and keep going rather than aborting the
-        # whole docs build on one bad notebook.
+        # baked in), so we record the failure and keep going; the build-finished
+        # handler turns the collected failures into a build error.
         proc = subprocess.run(
             [
                 "marimo",
@@ -190,9 +201,10 @@ def _patch_marimo_static_export():
         )
         if proc.returncode != 0:
             print(
-                f"[conf.py] WARNING: '{relative_path}' had cell errors during static "
+                f"[conf.py] ERROR: '{relative_path}' had cell errors during static "
                 f"export (output still written):\n{proc.stderr.strip()}"
             )
+            _marimo_export_failures.append((str(relative_path), proc.stderr.strip()))
 
         return {
             "name": output_name,
@@ -205,3 +217,30 @@ def _patch_marimo_static_export():
 
 
 _patch_marimo_static_export()
+
+
+def _fail_on_marimo_export_errors(app, exception):
+    """Fail the build if any notebook raised while being exported."""
+    # The build already failed for another reason; don't mask it.
+    if exception is not None or not _marimo_export_failures:
+        return
+
+    report = "\n\n".join(
+        f"{path}:\n{stderr}" for path, stderr in _marimo_export_failures
+    )
+    if os.environ.get("PYFDN_DOCS_ALLOW_NOTEBOOK_ERRORS") == "1":
+        print(
+            f"[conf.py] WARNING: {len(_marimo_export_failures)} notebook(s) had cell "
+            f"errors; failing is disabled via PYFDN_DOCS_ALLOW_NOTEBOOK_ERRORS:\n{report}"
+        )
+        return
+
+    raise RuntimeError(
+        f"{len(_marimo_export_failures)} example notebook(s) raised during static "
+        f"export. The generated HTML contains the traceback instead of the intended "
+        f"output, so this must not be published:\n\n{report}"
+    )
+
+
+def setup(app):
+    app.connect("build-finished", _fail_on_marimo_export_errors)


### PR DESCRIPTION
## Why

The docs build exports each marimo example with `marimo export html`, which runs the notebook server-side. When a cell raises, marimo still writes the HTML — with the traceback baked in where the output should be — and `docs/conf.py` only printed a warning. A broken example therefore reached the published site looking like a rendered page.

That is how `example_fdn_to_faust` shipped a `ModuleNotFoundError: No module named 'docs.references'` to the website without CI noticing (fixed separately in 30cea49).

Compounding it, the workflow's push path filter did not include `examples/**`, so pushing a notebook fix to `main` triggered no docs build at all.

## What

- **`docs/conf.py`** — collect every notebook whose export exits non-zero, then raise from a `build-finished` handler registered by a new `setup(app)`. Collecting rather than failing fast means one ~10-minute run reports every broken notebook; the handler returns early when the build already failed for another reason so it cannot mask the real error. `PYFDN_DOCS_ALLOW_NOTEBOOK_ERRORS=1` downgrades it back to a warning.
- **`.github/workflows/docs.yml`** — add `examples/**` to the push path filter.

Failing hard is safe here: the `[docs]` extra installs `adac`, `multislope` and `pyroomacoustics` (`pyproject.toml:85-87`), so every notebook can actually execute in CI. The `# requires:` headers in the examples are documentation only — nothing parses them.

## Testing

- `ruff` clean; workflow YAML parses with the new filter.
- Exercised all four handler paths directly: clean build, pre-existing exception (not masked), escape hatch (warns only), and a real failure (raises `RuntimeError` with the collected report).
- No full local `make html` — it re-executes every notebook and takes about as long as CI. This PR's own Docs CI run exercises it end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)