### PR TITLE
Website Enhancements: remove MATLAB mentions and fix line breaks in the examples

### DIFF
--- a/examples/allpass_FDN/example_allpass_FDN_homogeneous_mimo.py
+++ b/examples/allpass_FDN/example_allpass_FDN_homogeneous_mimo.py
@@ -147,10 +147,5 @@ def _(Fs, impulse_response, mo, pyFDN):
     return
 
 
-@app.cell
-def _():
-    return
-
-
 if __name__ == "__main__":
     app.run()

--- a/examples/example_absorption_geq.py
+++ b/examples/example_absorption_geq.py
@@ -20,9 +20,7 @@ def _(mo, pyFDN):
     mo.md(f"""
     # Absorption GEQ in an FDN
 
-    Demonstrates `pyFDN.absorption_geq`: frequency-dependent absorption designed
-    as a 10-band graphic EQ (11 biquad sections) targeting a given reverberation
-    time curve.
+    Demonstrates `pyFDN.absorption_geq`: frequency-dependent absorption designed as a 10-band graphic EQ (11 biquad sections) targeting a given reverberation time curve.
 
     The absorption filters are applied per delay line.  Here we:
 
@@ -93,8 +91,7 @@ def _(mo):
     mo.md(r"""
     ## Design absorption filters
 
-    `absorption_geq` converts T60 to a per-sample dB slope, fits a GEQ, and returns
-    SOS coefficients for each delay line.
+    `absorption_geq` converts T60 to a per-sample dB slope, fits a GEQ, and returns SOS coefficients for each delay line.
     """)
     return
 
@@ -114,9 +111,7 @@ def _(mo):
     mo.md(r"""
     ## Absorption filter magnitude responses
 
-    Plot the cascaded per-delay absorption filter response for each of the 8 delay
-    lines.  The curves should decay toward lower dB at higher frequencies (shorter
-    T60 = more attenuation per sample at HF).
+    Plot the cascaded per-delay absorption filter response for each of the 8 delay lines. The curves should decay toward lower dB at higher frequencies (shorter T60 = more attenuation per sample at HF).
     """)
     return
 
@@ -138,8 +133,7 @@ def _(mo):
     mo.md(r"""
     ## Compute impulse response
 
-    Build a FLAMO FDN with the GEQ absorption filters in the loop via `dss_to_flamo`.
-    Signal path: input → B → [delays → SOS → A] → C → output.
+    Build a FLAMO FDN with the GEQ absorption filters in the loop via `dss_to_flamo`. Signal path: input → B → [delays → SOS → A] → C → output.
     """)
     return
 
@@ -216,8 +210,7 @@ def _(mo):
     mo.md(r"""
     ## RT estimate vs target
 
-    Estimate RT in octave bands (63–8000 Hz) by Butterworth bandpass filtering
-    and compare with the design target.
+    Estimate RT in octave bands (63–8000 Hz) by Butterworth bandpass filtering and compare with the design target.
     """)
     return
 

--- a/examples/example_colorless_FDN.py
+++ b/examples/example_colorless_FDN.py
@@ -97,8 +97,7 @@ def _(mo):
     mo.md(r"""
     ## Load the packaged preset
 
-    `pyFDN.load_fdn_preset` returns the coefficients as an `FDNBuild`. We add
-    the desired decay with `pyFDN.build_set_decay` and render it directly.
+    `pyFDN.load_fdn_preset` returns the coefficients as an `FDNBuild`. We add the desired decay with `pyFDN.build_set_decay` and render it directly.
     """)
     return
 

--- a/examples/example_coupled_rooms.py
+++ b/examples/example_coupled_rooms.py
@@ -51,9 +51,7 @@ def _(mo):
     mo.md(r"""
     ## Single-room FDNs
 
-    Build each room with `pyFDN.fdn_build_gallery`. Both rooms have
-    frequency-dependent reverberation (RT at DC and at Nyquist, realised as
-    per-line first-order shelving absorption) and a different per-room output EQ.
+    Build each room with `pyFDN.fdn_build_gallery`. Both rooms have frequency-dependent reverberation (RT at DC and at Nyquist, realised as per-line first-order shelving absorption) and a different per-room output EQ.
     """)
     return
 
@@ -107,10 +105,7 @@ def _(mo):
     mo.md(r"""
     ## Concatenate and couple
 
-    The coupled FDN is the concatenation of the two rooms — block-diagonal
-    feedback matrix, stacked delays and absorption filters, source in room 1,
-    one output per room — composed with a single orthogonal **mixing matrix**
-    that couples the rooms by a coupling angle.
+    The coupled FDN is the concatenation of the two rooms — block-diagonal feedback matrix, stacked delays and absorption filters, source in room 1, one output per room — composed with a single orthogonal **mixing matrix** that couples the rooms by a coupling angle.
     """)
     return
 

--- a/examples/example_decorrelation.py
+++ b/examples/example_decorrelation.py
@@ -19,15 +19,9 @@ def _(mo):
     mo.md(r"""
     # Decorrelation in feedback delay networks
 
-    Analyses the decorrelation properties of an FDN with a velvet-noise
-    scattering feedback matrix.
+    Analyses the decorrelation properties of an FDN with a velvet-noise scattering feedback matrix.
 
-    The MIMO transfer function of an FDN factorises as
-    $H(z) = C \, \mathrm{adj}(P(z)) B \,/\, \det(P(z)) + D$ with the characteristic matrix $P(z) = \mathrm{diag}(z^{m}) - A(z)$.  The adjugate
-    matrix $\mathrm{adj}(P(z))$ collects the FIR filters that differentiate
-    the input-output paths: the more decorrelated its entries, the more
-    decorrelated the FDN outputs.  Here we compute the adjugate, then the
-    pairwise maximum cross-correlation between all of its entries.
+    The MIMO transfer function of an FDN factorises as $H(z) = C \, \mathrm{adj}(P(z)) B \,/\, \det(P(z)) + D$ with the characteristic matrix $P(z) = \mathrm{diag}(z^{m}) - A(z)$.  The adjugate matrix $\mathrm{adj}(P(z))$ collects the FIR filters that differentiate the input-output paths: the more decorrelated its entries, the more decorrelated the FDN outputs.  Here we compute the adjugate, then the pairwise maximum cross-correlation between all of its entries.
     """)
     return
 
@@ -59,8 +53,7 @@ def _(mo):
     mo.md(r"""
     ## Define FDN
 
-    A small FDN ($N = 4$) with random delays and a sparse velvet-noise
-    paraunitary feedback matrix (3 cascaded stages, sparsity 3).
+    A small FDN ($N = 4$) with random delays and a sparse velvet-noise paraunitary feedback matrix (3 cascaded stages, sparsity 3).
     """)
     return
 
@@ -88,9 +81,7 @@ def _(mo):
     mo.md(r"""
     ## Adjugate of the characteristic matrix
 
-    `loop_tf` constructs the polynomial matrix $P(z)$; `adj_poly` computes its
-    adjugate by evaluating $P$ on a DFT grid, taking the scalar adjugate at
-    every bin, and transforming back.
+    `loop_tf` constructs the polynomial matrix $P(z)$; `adj_poly` computes its adjugate by evaluating $P$ on a DFT grid, taking the scalar adjugate at every bin, and transforming back.
     """)
     return
 
@@ -145,10 +136,7 @@ def _(mo):
     mo.md(r"""
     ## Correlation analysis
 
-    `max_corr` computes the maximum normalized cross-correlation over all lags
-    between every pair of adjugate entries (16 signals for $N = 4$, i.e. a
-    $16 \times 16$ matrix).  The median and interquartile range of the
-    off-diagonal correlations summarise how decorrelated the paths are.
+    `max_corr` computes the maximum normalized cross-correlation over all lags between every pair of adjugate entries (16 signals for $N = 4$, i.e. a $16 \times 16$ matrix).  The median and interquartile range of the off-diagonal correlations summarise how decorrelated the paths are.
     """)
     return
 
@@ -174,10 +162,7 @@ def _(mo):
     mo.md(r"""
     ## Inter-channel maximum correlation matrix
 
-    Heatmap of $|\rho_{\max}|$ between all pairs of adjugate entries.  Axis
-    label $ij$ denotes the adjugate entry in row $i$, column $j$.  The
-    diagonal is the autocorrelation (1 by construction); low off-diagonal
-    values indicate good decorrelation.
+    Heatmap of $|\rho_{\max}|$ between all pairs of adjugate entries. Axis label $ij$ denotes the adjugate entry in row $i$, column $j$. The diagonal is the autocorrelation (1 by construction); low off-diagonal values indicate good decorrelation.
     """)
     return
 
@@ -215,12 +200,7 @@ def _(mo):
     mo.md(r"""
     ## Single input distributed to all delays
 
-    With a single source distributed equally to all delay lines
-    ($B = \mathbf{1}$), the numerator of the transfer function collapses to
-    the vector $\mathrm{adj}(P(z))\,\mathbf{1}$ — one FIR filter per output
-    channel.  The pairwise maximum correlation among these $N$ filters
-    indicates the decorrelation among the FDN output channels for a single
-    source.
+    With a single source distributed equally to all delay lines ($B = \mathbf{1}$), the numerator of the transfer function collapses to the vector $\mathrm{adj}(P(z))\,\mathbf{1}$ — one FIR filter per output channel. The pairwise maximum correlation among these $N$ filters indicates the decorrelation among the FDN output channels for a single source.
     """)
     return
 

--- a/examples/example_delay_matrix_density.py
+++ b/examples/example_delay_matrix_density.py
@@ -14,22 +14,6 @@ def _():
     return (mo,)
 
 
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    # Denser Reverberation with Delay Feedback Matrix
-
-    This example compares three FDN topologies and their **echo density** (Abel & Huang 2006):
-
-    1. **Vanilla FDN** — Build a complete FDN with `pyFDN.fdn_build_gallery`, bake in broadband decay, and render it with `pyFDN.dss_to_flamo`.
-    2. **Delay+matrix+delay in feedback** — Copy the model and replace the feedback path with **delay_in → matrix → delay_out** to increase echo density.
-    3. **Swapped feedforward/feedback** — Copy again and swap the base-delay and delay-matrix paths.
-
-    Reference: *Schlecht, S., Habets, E. (2019). Dense Reverberation with Delay Feedback Matrices.* Proc. IEEE Workshop Applicat. Signal Process. Audio Acoust. (WASPAA).
-    """)
-    return
-
-
 @app.cell
 def _(mo, pyFDN):
     mo.md(f"""
@@ -64,9 +48,7 @@ def _(mo):
     mo.md(r"""
     ## Parameters
 
-    Set RNG seed, sampling rate, number of delay lines **N**, broadband RT,
-    and base delays plus extra **delays_in** / **delays_out** for the
-    delay+matrix+delay chain.
+    Set RNG seed, sampling rate, number of delay lines **N**, broadband RT, and base delays plus extra **delays_in** / **delays_out** for the delay+matrix+delay chain.
     """)
     return
 
@@ -100,8 +82,7 @@ def _(mo):
     mo.md(r"""
     ## Build vanilla FDN
 
-    Create the complete broadband FDN with `pyFDN.fdn_build_gallery`, then
-    render it with `pyFDN.dss_to_flamo`.
+    Create the complete broadband FDN with `pyFDN.fdn_build_gallery`, then render it with `pyFDN.dss_to_flamo`.
     """)
     return
 
@@ -139,9 +120,7 @@ def _(mo):
     mo.md(r"""
     ## Copy model and insert delay+matrix+delay in feedback
 
-    Deep-copy the vanilla model, split its total delays into a base delay and
-    **delay_in → matrix → delay_out**, then move the latter path into the
-    feedback branch.
+    Deep-copy the vanilla model, split its total delays into a base delay and **delay_in → matrix → delay_out**, then move the latter path into the feedback branch.
     """)
     return
 
@@ -166,8 +145,7 @@ def _(mo):
     mo.md(r"""
     ## Copy model and swap feedforward and feedback
 
-    Make another copy of the delay-matrix model and **swap** its two recursion
-    paths without changing any modules or parameter values.
+    Make another copy of the delay-matrix model and **swap** its two recursion paths without changing any modules or parameter values.
     """)
     return
 

--- a/examples/example_dss_to_pr_direct.py
+++ b/examples/example_dss_to_pr_direct.py
@@ -19,9 +19,8 @@ def _(mo):
     mo.md(r"""
     # DSS→PR example
 
-    Uses ``dss_to_pr`` with modes ``eig``, ``roots`` (pure-NumPy pole finding) and
-    ``eai`` (Ehrlich–Aberth iteration in ``w = 1/z`` via FLAMO). Compares the
-    time-domain IR from ``dss_to_impz`` with the modal reconstruction from each mode.
+    Uses ``dss_to_pr`` with modes ``eig``, ``roots`` (pure-NumPy pole finding) and ``eai`` (Ehrlich–Aberth iteration in ``w = 1/z`` via FLAMO). Compares the time-domain IR from ``dss_to_impz`` with
+    the modal reconstruction from each mode.
     """)
     return
 

--- a/examples/example_dss_to_ss.py
+++ b/examples/example_dss_to_ss.py
@@ -97,8 +97,7 @@ def _(mo):
     mo.md(r"""
     ## Equivalent state-space system
 
-    The single state-space matrices `(A, b, c, d)` returned by `pyFDN.dss_to_ss`,
-    expanding the delay lines into unit-delay states.
+    The single state-space matrices `(A, b, c, d)` returned by `pyFDN.dss_to_ss`, expanding the delay lines into unit-delay states.
     """)
     return
 

--- a/examples/example_fdn_eigenvectors.py
+++ b/examples/example_fdn_eigenvectors.py
@@ -19,16 +19,13 @@ def _(mo):
     mo.md(r"""
     # FDN eigenvectors (mode shapes)
 
-    Demonstrates how to compute the mode shapes of an FDN from the left and
-    right eigenvectors of the loop polynomial $P(z) = D_m(z) - A$.
+    Demonstrates how to compute the mode shapes of an FDN from the left and right eigenvectors of the loop polynomial $P(z) = D_m(z) - A$.
 
     Each residue factors into the input/output drive and an undriven part:
 
     $$\rho_i = \frac{(c\, r_i)\,(l_i^H b)}{l_i^H P'(\lambda_i)\, r_i},$$
 
-    where $r_i$ and $l_i$ are the right/left null vectors of $P(\lambda_i)$.
-    The eigenvectors live on the delay lines; expanding each entry along its
-    delay line with $\lambda_i^k$ gives the mode shape over the full state.
+    where $r_i$ and $l_i$ are the right/left null vectors of $P(\lambda_i)$. The eigenvectors live on the delay lines; expanding each entry along its delay line with $\lambda_i^k$ gives the mode shape over the full state.
     """)
     return
 
@@ -97,8 +94,7 @@ def _(mo):
     mo.md(r"""
     ## Residues from eigenvectors
 
-    Reassemble the residues from the eigenvectors and the undriven part; the
-    result matches the residues returned by the modal decomposition.
+    Reassemble the residues from the eigenvectors and the undriven part; the result matches the residues returned by the modal decomposition.
     """)
     return
 
@@ -150,9 +146,7 @@ def _(mo):
     mo.md(r"""
     ## Mode shapes over the full state space
 
-    Expand the eigenvectors along each delay line: state $k$ of delay line $j$
-    carries $r_{j,i}\,\lambda_i^k$. Horizontal lines mark the delay-line
-    boundaries.
+    Expand the eigenvectors along each delay line: state $k$ of delay line $j$ carries $r_{j,i}\,\lambda_i^k$. Horizontal lines mark the delay-line boundaries.
     """)
     return
 

--- a/examples/example_fdn_gallery.py
+++ b/examples/example_fdn_gallery.py
@@ -22,15 +22,9 @@ def _(mo, pyFDN):
 
     Overview of feedback matrices and full FDN systems available in pyFDN.
 
-    `fdn_matrix_gallery` provides pure feedback matrices — each is an N×N matrix
-    used as the recirculation matrix in a delay network. Losslessness properties are
-    characterised by orthogonality (`A @ A.T ≈ I`) and unilosslessness (diagonal
-    similarity to an orthogonal matrix).
+    `fdn_matrix_gallery` provides pure feedback matrices — each is an N×N matrix used as the recirculation matrix in a delay network. Losslessness properties are characterised by orthogonality (`A @ A.T ≈ I`) and unilosslessness (diagonal similarity to an orthogonal matrix).
 
-    `fdn_system_gallery` provides complete state-space systems `(A, B, C, D)` —
-    structures where the input/output coupling is part of the design, such as
-    series allpass, nested allpass, and the Schroeder reverberator. These are
-    checked for the stronger uniallpass condition.
+    `fdn_system_gallery` provides complete state-space systems `(A, B, C, D)` — structures where the input/output coupling is part of the design, such as series allpass, nested allpass, and the Schroeder reverberator. These are checked for the stronger uniallpass condition.
 
     Reference: *{pyFDN.paper_link("Schlecht2020FDNTBFeedbackDelay")}*
 
@@ -75,8 +69,7 @@ def _(mo):
     mo.md(r"""
     ## Build matrices and check losslessness
 
-    A matrix is orthogonal if `A @ A.T ≈ I`.  A matrix is spectrally lossless if
-    all eigenvalues lie on the unit circle.  The table below shows both checks.
+    A matrix is orthogonal if `A @ A.T ≈ I`.  A matrix is spectrally lossless if all eigenvalues lie on the unit circle.  The table below shows both checks.
     """)
     return
 
@@ -132,18 +125,17 @@ def _(mo, pyFDN, results):
     return
 
 
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
+@app.cell
+def _(mo, pyFDN):
+    mo.md(f"""
     ---
 
     # Filter Matrix Gallery
 
-    `filter_matrix_gallery` provides FIR *filter* feedback matrices — each
-    entry of the N×N matrix is an FIR filter, so the matrix scatters energy
-    over time as well as across delay lines (Schlecht & Habets 2020,
-    *Scattering in Feedback Delay Networks*). All types are paraunitary
-    (lossless): $A^T(z^{-1})\,A(z) = I$.
+    `filter_matrix_gallery` provides FIR *filter* feedback matrices — each entry of the N×N matrix is an FIR filter, so the matrix scatters energy over time as well as across delay lines. All types are paraunitary (lossless): $A^T(z^{-1})\,A(z) = I$.
+
+    Reference: *{pyFDN.paper_link("Scattering_in_Feedback_Delay_Networks")}*. 
+
     """)
     return
 
@@ -162,8 +154,7 @@ def _(mo):
     mo.md(r"""
     ## Matrix impulse responses
 
-    Each subplot grid shows the FIR of every matrix entry; the paraunitarity
-    check is printed in the title.
+    Each subplot grid shows the FIR of every matrix entry; the paraunitarity check is printed in the title.
     """)
     return
 
@@ -192,8 +183,7 @@ def _(mo):
 
     # Complete FDN Build Gallery
 
-    `fdn_build_gallery` provides ready-to-render FDN parameters: feedback,
-    input/output/direct matrices, delays, sample rate, and optional loop filters.
+    `fdn_build_gallery` provides ready-to-render FDN parameters: feedback, input/output/direct matrices, delays, sample rate, and optional loop filters.
     """)
     return
 
@@ -258,9 +248,7 @@ def _(mo):
 
     # FDN System Gallery
 
-    Overview of full FDN system types available in `pyFDN.fdn_system_gallery`.
-    Each type returns a complete state-space system `(A, B, C, D)` visualised
-    as the block matrix `[A  b; c  d]`.
+    Overview of full FDN system types available in `pyFDN.fdn_system_gallery`. Each type returns a complete state-space system `(A, B, C, D)` visualised as the block matrix `[A  b; c  d]`.
     """)
     return
 

--- a/examples/example_fdn_to_faust.py
+++ b/examples/example_fdn_to_faust.py
@@ -5,7 +5,7 @@
 
 import marimo
 
-__generated_with = "0.23.16"
+__generated_with = "0.23.9"
 app = marimo.App()
 
 
@@ -23,11 +23,7 @@ def _(mo):
     mo.md(r"""
     # FDN to FAUST: compiling a pyFDN design to real-time DSP
 
-    A pyFDN design lives as NumPy arrays and, through `dss_to_flamo`, as a
-    differentiable FLAMO graph. Neither runs in a DAW. [`adac`](https://github.com/cucuwritescode/adac)
-    closes that gap: it walks the FLAMO graph, extracts every delay, gain,
-    matrix and filter into a JSON intermediate representation, and emits
-    [FAUST](https://faust.grame.fr) source that compiles to a plugin.
+    A pyFDN design lives as NumPy arrays and, through `dss_to_flamo`, as a differentiable FLAMO graph. Neither runs in a DAW. [`adac`](https://github.com/cucuwritescode/adac) closes that gap: it walks the FLAMO graph, extracts every delay, gain, matrix and filter into a JSON intermediate representation, and emits [FAUST](https://faust.grame.fr) source that compiles to a plugin.
 
     **The pipeline:**
 
@@ -37,8 +33,7 @@ def _(mo):
     4. `adac.json_to_faust` — emit FAUST, with optional `rt60` / `dry_wet` macro knobs;
     5. run it: one click in the browser IDE, or `faust2juce` / `adac.export_juce` for a VST3.
 
-    The last section renders the *compiled* FAUST and overlays it on the FLAMO
-    reference, so the translation is checked, not assumed.
+    The last section renders the *compiled* FAUST and overlays it on the FLAMO reference, so the translation is checked, not assumed.
     """)
     return
 
@@ -91,13 +86,11 @@ def _(mo):
     mo.md(r"""
     ## 1. Design the FDN
 
-    A six-line FDN from the gallery, mono in and stereo out: random orthogonal
-    feedback, one-pole absorption per delay line giving 1.8 s at DC and 0.4 s at
-    Nyquist, unity direct path. The output matrix `C` is `(2, 6)` with random
-    gains, so the two channels are decorrelated mixes of the same delay lines —
-    with `io_type="ones"` both columns would be identical and the result would
-    be dual mono. Nothing here is FAUST-specific: this is the ordinary pyFDN
-    design loop, and the rest of the notebook never assumes a channel count.
+    A six-line FDN from the gallery, mono in and stereo out: random orthogonal feedback, one-pole absorption per delay line giving 1.8 s at DC and 0.4 s at Nyquist, unity direct path.
+
+    The output matrix `C` is `(2, 6)` with random gains, so the two channels are decorrelated mixes of the same delay lines — with `io_type="ones"` both columns would be identical and the result would be dual mono.
+
+    Nothing here is FAUST-specific: this is the ordinary pyFDN design loop, and the rest of the notebook never assumes a channel count.
     """)
     return
 
@@ -149,10 +142,7 @@ def _(mo):
     mo.md(r"""
     ## 2. Extract the parameters
 
-    `flamo_to_json` traverses the FLAMO graph and detaches every parameter into
-    a plain dict. Extraction is map-aware: a matrix with a non-identity
-    parametrisation (orthogonal, Householder, Hadamard) serialises the
-    *effective* matrix the model applies, so what FAUST gets is what FLAMO ran.
+    `flamo_to_json` traverses the FLAMO graph and detaches every parameter into a plain dict. Extraction is map-aware: a matrix with a non-identity parametrisation (orthogonal, Householder, Hadamard) serialises the *effective* matrix the model applies, so what FAUST gets is what FLAMO ran.
     """)
     return
 
@@ -198,12 +188,9 @@ def _(mo):
     mo.md(r"""
     ## 3. Certify stability
 
-    Before anything is emitted, `certify` bounds the loop gain around every
-    feedback path: the product of per-element spectral norms, evaluated at the
-    parameter values *as they will be written into the FAUST source* (single
-    precision, ten significant figures). Below one at every frequency is a
-    sufficient condition for BIBO stability, so a `certified-stable` verdict
-    rules out a plugin that blows up after the rounding a code generator does.
+    Before anything is emitted, `certify` bounds the loop gain around every feedback path: the product of per-element spectral norms, evaluated at the parameter values *as they will be written into the FAUST source* (single precision, ten significant figures).
+
+    Below one at every frequency is a sufficient condition for BIBO stability, so a `certified-stable` verdict rules out a plugin that blows up after the rounding a code generator does.
     """)
     return
 
@@ -265,11 +252,8 @@ def _(faust_code, mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    The whole reverberator is one `process` line. The FDN core is FAUST's `~`
-    feedback operator wrapped around `delays : absorption`, with the feedback
-    matrix hoisted into a sum-of-products function `fB`. Note the delay lengths:
-    `~` inserts one implicit sample of delay, and adac subtracts it from every
-    line so the network keeps the exact delays pyFDN designed.
+    The whole reverberator is one `process` line. The FDN core is FAUST's `~` feedback operator wrapped around `delays : absorption`, with the feedback matrix hoisted into a sum-of-products function `fB`. Note the delay lengths:
+    `~` inserts one implicit sample of delay, and adac subtracts it from every line so the network keeps the exact delays pyFDN designed.
     """)
     return
 
@@ -299,11 +283,7 @@ def _(mo):
     mo.md(r"""
     ## 5. Run it
 
-    The shortest path to a running artifact needs no toolchain at all: the FAUST
-    web IDE accepts a whole program as a base64 `inline=` parameter, compiles it
-    to WebAssembly in the browser and starts it. The link below carries this
-    exact FDN, sliders and all — open it, allow audio, and the `rt60` and
-    `dry/wet` knobs are live.
+    The shortest path to a running artifact needs no toolchain at all: the FAUST web IDE accepts a whole program as a base64 `inline=` parameter, compiles it to WebAssembly in the browser and starts it. The link below carries this exact FDN, sliders and all — open it, allow audio, and the `rt60` and `dry/wet` knobs are live.
     """)
     return
 
@@ -332,9 +312,7 @@ def _(mo):
     mo.md(r"""
     ### Native targets
 
-    With the FAUST distribution installed, the same file goes to C++, a JUCE
-    plugin project, or a standalone app. The cell below runs the compiler if it
-    is on `PATH` and otherwise just lists the commands.
+    With the FAUST distribution installed, the same file goes to C++, a JUCE plugin project, or a standalone app. The cell below runs the compiler if it is on `PATH` and otherwise just lists the commands.
     """)
     return
 
@@ -399,13 +377,9 @@ def _(mo):
     mo.md(r"""
     ## 6. Does the plugin match the design?
 
-    Emitting code is only useful if the compiled DSP is the network pyFDN
-    designed. [DawDreamer](https://github.com/DBraun/DawDreamer) embeds libfaust,
-    so the generated `.dsp` can be compiled and rendered offline right here and
-    compared sample by sample against FLAMO's frequency-domain response.
+    Emitting code is only useful if the compiled DSP is the network pyFDN designed. [DawDreamer](https://github.com/DBraun/DawDreamer) embeds libfaust, so the generated `.dsp` can be compiled and rendered offline right here and compared sample by sample against FLAMO's frequency-domain response.
 
-    Optional: `pip install dawdreamer`. Without it the rest of the notebook still
-    runs; this section reports as skipped.
+    Optional: `pip install dawdreamer`. Without it the rest of the notebook still runs; this section reports as skipped.
     """)
     return
 
@@ -492,8 +466,7 @@ def _(mo):
     mo.md(r"""
     ### Listen
 
-    A dry synth phrase through the FLAMO model and, when DawDreamer is
-    available, through the compiled FAUST plugin. Same network, two runtimes.
+    A dry synth phrase through the FLAMO model and, when DawDreamer is available, through the compiled FAUST plugin. Same network, two runtimes.
     """)
     return
 
@@ -525,16 +498,11 @@ def _(mo):
     mo.md(r"""
     ## Where this lands
 
-    The design stays in Python — gallery matrices, absorption fitting,
-    optimisation, the analysis tools in the rest of this gallery — and the
-    deployment artifact is generated, not re-implemented by hand. A colourless
-    FDN trained with `pyFDN.train`, or an FDN fitted to a measured RIR by
-    `example_rir_to_fdn`, compiles through exactly the same three calls, because
-    the compiler reads the FLAMO graph rather than any particular design recipe.
+    The design stays in Python — gallery matrices, absorption fitting, optimisation, the analysis tools in the rest of this gallery — and the deployment artifact is generated, not re-implemented by hand.
 
-    `adac.HotReload` closes the loop further: it republishes the model to a
-    running FAUST plugin during training, so the optimisation is audible while
-    it runs.
+    A colourless FDN trained with `pyFDN.train`, or an FDN fitted to a measured RIR by `example_rir_to_fdn`, compiles through exactly the same three calls, because the compiler reads the FLAMO graph rather than any particular design recipe.
+
+    `adac.HotReload` closes the loop further: it republishes the model to a running FAUST plugin during training, so the optimisation is audible while it runs.
     """)
     return
 

--- a/examples/example_multislope_rir_to_fdn.py
+++ b/examples/example_multislope_rir_to_fdn.py
@@ -5,7 +5,7 @@
 
 import marimo
 
-__generated_with = "0.23.16"
+__generated_with = "0.23.9"
 app = marimo.App()
 
 
@@ -21,22 +21,15 @@ def _(mo):
     mo.md(r"""
     # Multi-slope decay: from a coupled-space RIR to an FDN
 
-    A single room decays with one exponential slope per frequency band, and
-    ``pyFDN.estimate_rt_bands`` is built for exactly that case. Two coupled
-    rooms do not: energy leaks from the small room into the large one, so the
-    energy decay curve (EDC) bends — a fast slope early on, a slow one later,
-    and a single reverberation time fitted to it describes neither room.
+    A single room decays with one exponential slope per frequency band, and ``pyFDN.estimate_rt_bands`` is built for exactly that case. Two coupled rooms do not: energy leaks from the small room into the large one, so the energy decay curve (EDC) bends — a fast slope early on, a slow one later, and a single reverberation time fitted to it describes neither room.
 
     This example estimates a **multi-slope** decay and turns it into an FDN:
 
     1. Render a coupled-rooms RIR (two FDNs joined by a mixing matrix).
     2. Show that a single-slope RT lands between the two true decay times.
-    3. Fit two slopes per octave band with **DecayFitNet**, from the
-       [`multislope`](https://pypi.org/project/multislope/) package.
-    4. Convert the fitted slope amplitudes into per-slope initial levels with
-       `pyFDN.slope_amplitude_to_level`.
-    5. Build **one FDN per slope**, sum them, and compare the octave-band EDCs
-       with the original.
+    3. Fit two slopes per octave band with **DecayFitNet**, from the [`multislope`](https://pypi.org/project/multislope/) package.
+    4. Convert the fitted slope amplitudes into per-slope initial levels with `pyFDN.slope_amplitude_to_level`.
+    5. Build **one FDN per slope**, sum them, and compare the octave-band EDCs with the original.
     """)
     return
 
@@ -61,13 +54,7 @@ def _(mo):
     mo.md(r"""
     ## A coupled-space impulse response
 
-    Two single-room FDNs — a small bright room (RT 0.7 s at DC) and a large
-    reverberant one (RT 3.2 s) — are concatenated into one FDN with a
-    block-diagonal feedback matrix and coupled by an orthogonal block rotation,
-    as in the *Coupled Rooms* example.  The source sits in the small room, and
-    so does the receiver: it picks up the small room directly and the large
-    room only weakly, which is the geometry that produces a pronounced
-    double-slope decay.
+    Two single-room FDNs — a small bright room (RT 0.7 s at DC) and a large reverberant one (RT 3.2 s) — are concatenated into one FDN with a block-diagonal feedback matrix and coupled by anorthogonal block rotation, as in the *Coupled Rooms* example.  The source sits in the small room, and so does the receiver: it picks up the small room directly and the large room only weakly, which is the geometry that produces a pronounced double-slope decay.
     """)
     return
 
@@ -146,11 +133,7 @@ def _(fs, mo, pyFDN, rir):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    The decay times of the two rooms *in isolation* are known here, because the
-    rooms were designed: the per-sample gain of each room's absorption filters
-    gives its reverberation time as a function of frequency.  They are the
-    reference below — but note that the coupled system does not decay at
-    exactly these rates, as the fit will show.
+    The decay times of the two rooms *in isolation* are known here, because the rooms were designed: the per-sample gain of each room's absorption filters gives its reverberation time as a function of frequency. They are the reference below — but note that the coupled system does not decay at exactly these rates, as the fit will show.
     """)
     return
 
@@ -175,10 +158,7 @@ def _(mo):
     mo.md(r"""
     ## One reverberation time per band is not enough
 
-    `pyFDN.estimate_rt_bands` fits a single line to the Schroeder decay curve
-    between -5 dB and -35 dB.  On a double-slope decay that line is a
-    compromise: the estimate sits between the two true decay times and follows
-    neither.
+    `pyFDN.estimate_rt_bands` fits a single line to the Schroeder decay curve between -5 dB and -35 dB. On a double-slope decay that line is a compromise: the estimate sits between the two true decay times and follows neither.
     """)
     return
 
@@ -196,18 +176,11 @@ def _(mo, pyFDN):
     mo.md(f"""
     ## Fitting two slopes with DecayFitNet
 
-    `multislope.DecayFitNet` filters the RIR into octave bands, backward
-    integrates each band, and predicts the decay times `T`, the slope
-    amplitudes `A` and the noise floor `N` of a multi-exponential decay model.
-    The network is described in
-    {pyFDN.paper_link("Neural_Network_For_Multi_Exponential_Sound_Energy_Decay_Analysis")}.
+    `multislope.DecayFitNet` filters the RIR into octave bands, backward integrates each band, and predicts the decay times `T`, the slope amplitudes `A` and the noise floor `N` of a multi-exponential decay model. 
+    The network is described in {pyFDN.paper_link("Neural_Network_For_Multi_Exponential_Sound_Energy_Decay_Analysis")}.
 
-    The network resamples every EDC to a fixed length, so the analysis window
-    sets the time resolution of the fit: a 0.6 s slope inside a 5.5 s window
-    occupies only a handful of samples and gets smeared into the late decay.
-    Trimming the RIR to roughly the range that carries useful decay — here 2 s,
-    below which the FDN response has fallen past -60 dB — keeps both slopes
-    resolvable.
+    The network resamples every EDC to a fixed length, so the analysis window sets the time resolution of the fit: a 0.6 s slope inside a 5.5 s window occupies only a handful of samples and gets smeared into the late decay.
+    Trimming the RIR to roughly the range that carries useful decay — here 2 s, below which the FDN response has fallen past -60 dB — keeps both slopes resolvable.
     """)
     return
 
@@ -305,35 +278,19 @@ def _(
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    The single-slope estimate runs between the two rooms, while the fitted
-    slopes track them individually.  The slow slope lands below the large
-    room's dotted curve, and that is the coupling rather than an estimation
-    error: the dotted curves are the decay times the two rooms would have in
-    isolation, but the coupling rotation mixes their feedback loops, so the
-    decay rates of the *coupled* system are pulled towards each other.  The
-    slow decay time of the coupled space therefore sits somewhere between the
-    two isolated ones, and moves further from the large room the larger the
-    coupling angle.
+    The single-slope estimate runs between the two rooms, while the fitted slopes track them individually.
+    The slow slope lands below the large room's dotted curve, and that is the coupling rather than an estimation error: the dotted curves are the decay times the two rooms would have in isolation, but the coupling rotation mixes their feedback loops, so the decay rates of the *coupled* system are pulled towards each other. The slow decay time of the coupled space therefore sits somewhere between the two isolated ones, and moves further from the large room the larger the coupling angle.
 
     ## One FDN per slope
 
-    Each slope becomes its own FDN.  A GEQ absorption filter per delay line
-    gives the FDN the decay time of that slope, and an output GEQ sets its
-    initial level.  The level target is the *difference* between the level the
-    slope should have and the level the unequalized FDN happens to produce, so
-    the design corrects itself.
+    Each slope becomes its own FDN. A GEQ absorption filter per delay line gives the FDN the decay time of that slope, and an output GEQ sets its initial level. The level target is the difference* between the level the slope should have and the level the unequalized FDN happens to produce, so the design corrects itself.
 
     The two GEQ designs work on a 10-point grid (DC, 63 Hz … 8 kHz, Nyquist);
     the octave-band estimates are extended to it by repeating the edge bands.
 
-    `pyFDN.design_geq` returns its biquad sections in the unnormalised form
-    `[b0, b1, b2, a0, a1, a2]`, straight out of the analytic filter formulas,
-    so `a0` is not 1 (a peaking section, for instance, has `a0 = sqrt(g) + t`).
-    Filtering code expects the normalised form, so each section is divided by
-    its own `a0` — column 3 of the SOS matrix — which scales `b` and `a`
-    together and leaves the transfer function unchanged.
-    `pyFDN.absorption_geq` does this internally; `design_geq` leaves it to the
-    caller.
+    `pyFDN.design_geq` returns its biquad sections in the unnormalised form `[b0, b1, b2, a0, a1, a2]`, straight out of the analytic filter formulas, so `a0` is not 1 (a peaking section, for instance, has `a0 = sqrt(g) + t`).
+
+    Filtering code expects the normalised form, so each section is divided by its own `a0` — column 3 of the SOS matrix — which scales `b` and `a` together and leaves the transfer function unchanged. `pyFDN.absorption_geq` does this internally; `design_geq` leaves it to the caller.
     """)
     return
 
@@ -418,9 +375,7 @@ def _(mo):
     mo.md(r"""
     ## Energy decay curves
 
-    The comparison that matters is the octave-band EDC: the sum of the two
-    FDNs should bend the same way as the coupled-rooms response.  Both curves
-    are normalised to 0 dB at the onset.
+    The comparison that matters is the octave-band EDC: the sum of the two FDNs should bend the same way as the coupled-rooms response. Both curves are normalised to 0 dB at the onset.
     """)
     return
 
@@ -481,9 +436,7 @@ def _(mo):
     mo.md(r"""
     ## Test: the FDNs realise the estimated decay
 
-    Two checks.  Each per-slope FDN must reproduce the decay time it was
-    designed for, and the sum of the two must follow the coupled-rooms EDC
-    over its first 40 dB — the range the two-slope model describes.
+    Two checks. Each per-slope FDN must reproduce the decay time it was designed for, and the sum of the two must follow the coupled-rooms EDC over its first 40 dB — the range the two-slope model describes.
     """)
     return
 

--- a/examples/example_nearest_sign_agnostic_orthogonal.py
+++ b/examples/example_nearest_sign_agnostic_orthogonal.py
@@ -20,13 +20,9 @@ def _(mo, pyFDN):
     mo.md(f"""
     # Nearest Sign-Agnostic Orthogonal Matrix
 
-    Given a non-negative matrix **B** (e.g., measured energy flow between delay
-    lines), find the orthogonal matrix **U** that minimises ``‖B − |U|‖_F`` where
-    ``|·|`` is element-wise absolute value.
+    Given a non-negative matrix **B** (e.g., measured energy flow between delay lines), find the orthogonal matrix **U** that minimises ``‖B − |U|‖_F`` where ``|·|`` is element-wise absolute value.
 
-    The challenge is assigning the right ±1 sign to each element.  A naive
-    approach (just solving the ordinary Procrustes problem with `nearest_orthogonal`)
-    ignores the freedom in signs.  The sign-agnostic algorithm does:
+    The challenge is assigning the right ±1 sign to each element. A naive approach (just solving the ordinary Procrustes problem with `nearest_orthogonal`) ignores the freedom in signs. The sign-agnostic algorithm does:
 
     1. Normalise **B** to doubly stochastic via Sinkhorn-Knopp.
     2. Initialise with a random sign pattern.
@@ -55,8 +51,7 @@ def _(mo):
     mo.md(r"""
     ## Setup
 
-    Generate a random orthogonal matrix **A** and strip its signs to get **B = |A|**.
-    The goal is to recover a matrix close to **A** from **B** alone.
+    Generate a random orthogonal matrix **A** and strip its signs to get **B = |A|**. The goal is to recover a matrix close to **A** from **B** alone.
     """)
     return
 
@@ -78,8 +73,7 @@ def _(mo):
     mo.md(r"""
     ## Solve
 
-    Compare the naive **nearest_orthogonal** (ignores sign freedom) against the
-    **sign-agnostic** solution.
+    Compare the naive **nearest_orthogonal** (ignores sign freedom) against the **sign-agnostic** solution.
     """)
     return
 

--- a/examples/example_paraunitary_fdn.py
+++ b/examples/example_paraunitary_fdn.py
@@ -20,9 +20,7 @@ def _(mo, pyFDN):
     mo.md(f"""
     # Filter feedback delay network (FFDN) with paraunitary feedback matrix
 
-    An FDN with a *paraunitary* (FIR, lossless) scattering matrix in the loop.
-    The example computes the impulse response by time-domain recursion and by
-    modal decomposition, and verifies that the system is lossless (all poles
+    An FDN with a *paraunitary* (FIR, lossless) scattering matrix in the loop. The example computes the impulse response by time-domain recursion and by modal decomposition, and verifies that the system is lossless (all poles
     on the unit circle).
 
     Reference: *{pyFDN.paper_link("Scattering_in_Feedback_Delay_Networks")}.*
@@ -102,8 +100,7 @@ def _(mo):
     mo.md(r"""
     ## Verify paraunitarity
 
-    A paraunitary matrix satisfies $A^T(z^{-1})\,A(z) = I$; in the time domain
-    the matrix impulse response is lossless.
+    A paraunitary matrix satisfies $A^T(z^{-1})\,A(z) = I$; in the time domain the matrix impulse response is lossless.
     """)
     return
 
@@ -123,12 +120,7 @@ def _(mo):
     mo.md(r"""
     ## Impulse response and modal decomposition
 
-    The FIR feedback matrix runs directly in the time-domain recursion.
-    For the modal decomposition the FIR matrix is placed as a FLAMO Filter
-    module in the loop (`dss_to_flamo`) and `flamo_to_pr` refines the poles
-    with Ehrlich–Aberth iteration. The FIR feedback adds poles beyond the
-    delay count, so the number of root seeds is set to the degree of the
-    generalized characteristic polynomial.
+    The FIR feedback matrix runs directly in the time-domain recursion. For the modal decomposition the FIR matrix is placed as a FLAMO Filter module in the loop (`dss_to_flamo`) and `flamo_to_pr` refines the poles with Ehrlich–Aberth iteration. The FIR feedback adds poles beyond the delay count, so the number of root seeds is set to the degree of the generalized characteristic polynomial.
     """)
     return
 
@@ -210,8 +202,7 @@ def _(mo):
     mo.md(r"""
     ## Poles and residues
 
-    The FFDN is lossless: all pole magnitudes are 0 dB. The residue magnitudes
-    spread over a wide range.
+    The FFDN is lossless: all pole magnitudes are 0 dB. The residue magnitudes spread over a wide range.
     """)
     return
 

--- a/examples/example_pole_boundaries.py
+++ b/examples/example_pole_boundaries.py
@@ -19,14 +19,9 @@ def _(mo):
     mo.md(r"""
     # Frequency-dependent pole boundaries
 
-    FDN with frequency-dependent absorption filters, but *not* with homogeneous
-    (delay-proportional) decay. Still, boundaries for the pole magnitudes can be
-    computed from the singular values of the loop transfer function and tested
-    against the actual poles.
+    FDN with frequency-dependent absorption filters, but *not* with homogeneous (delay-proportional) decay. Still, boundaries for the pole magnitudes can be computed from the singular values of the loop transfer function and tested against the actual poles.
 
-    The loop here is $P(z) = \mathrm{diag}(z^{m}) - A\,\mathrm{diag}(h(z))$ with
-    a two-tap FIR absorption filter $h(z) = 0.65 + 0.3 z^{-1}$ on every delay
-    line and a non-orthogonal feedback matrix $A = Q/1.5$.
+    The loop here is $P(z) = \mathrm{diag}(z^{m}) - A\,\mathrm{diag}(h(z))$ with a two-tap FIR absorption filter $h(z) = 0.65 + 0.3 z^{-1}$ on every delay line and a non-orthogonal feedback matrix $A = Q/1.5$.
     """)
     return
 
@@ -100,12 +95,7 @@ def _(mo):
     mo.md(r"""
     ## Pole boundaries and modal decomposition
 
-    `pole_boundaries` combines the singular values of the feedback matrix with
-    the absorption magnitude responses and group delays. For the poles, the
-    FIR absorption is placed as an SOS filter behind the delays in a FLAMO
-    model (loop: delay → absorption → $A$) via `dss_to_flamo`, and
-    `flamo_to_pr` extracts the poles with Ehrlich–Aberth refinement in the
-    $w = z^{-1}$ domain.
+    `pole_boundaries` combines the singular values of the feedback matrix with the absorption magnitude responses and group delays. For the poles, the FIR absorption is placed as an SOS filter  behind the delays in a FLAMO model (loop: delay → absorption → $A$) via `dss_to_flamo`, and `flamo_to_pr` extracts the poles with Ehrlich–Aberth refinement in the $w = z^{-1}$ domain.
     """)
     return
 
@@ -162,8 +152,7 @@ def _(mo):
     mo.md(r"""
     ## Poles between the boundaries
 
-    Pole magnitudes converted to T60 over frequency. All poles lie between the
-    minimum and maximum boundary curves.
+    Pole magnitudes converted to T60 over frequency. All poles lie between the minimum and maximum boundary curves.
     """)
     return
 

--- a/examples/example_process_fdn.py
+++ b/examples/example_process_fdn.py
@@ -19,8 +19,7 @@ def _(mo):
     mo.md(r"""
     # process_fdn — Pure DSS Simulation
 
-    Demonstrates `pyFDN.process_fdn` for time-domain simulation of a feedback delay network with static matrices.
-    A dry audio signal is run through the FDN to produce reverberation.
+    Demonstrates `pyFDN.process_fdn` for time-domain simulation of a feedback delay network with static matrices. A dry audio signal is run through the FDN to produce reverberation.
 
     For FDNs with absorption filters or learnable parameters, use the FLAMO path (`dss_to_flamo`).
     """)

--- a/examples/example_process_fdn_vs_flamo.py
+++ b/examples/example_process_fdn_vs_flamo.py
@@ -20,21 +20,12 @@ def _(mo, pyFDN):
     mo.md(f"""
     # Time-domain FDN vs FLAMO with GEQ absorption
 
-    The same FDN with frequency-dependent absorption is rendered by two
-    independent implementations and the impulse responses are compared:
+    The same FDN with frequency-dependent absorption is rendered by two independent implementations and the impulse responses are compared:
 
-    1. **`process_fdn`** — block time-domain recursion; the per-delay-line
-       SOS cascades run in a `td.SOSBank` and the FIR feedback matrix in
-       a `td.MatrixFIR`, both with persistent state.
-    2. **`dss_to_flamo`** — FLAMO frequency-domain model with the same SOS
-       cascades as `parallelSOSFilter` and the FIR feedback matrix as a
-       `Filter` module in the loop.
+    1. **`process_fdn`** — block time-domain recursion; the per-delay-line SOS cascades run in a `td.SOSBank` and the FIR feedback matrix in a `td.MatrixFIR`, both with persistent state.
+    2. **`dss_to_flamo`** — FLAMO frequency-domain model with the same SOS cascades as `parallelSOSFilter` and the FIR feedback matrix as a `Filter` module in the loop.
 
-    The feedback matrix is a paraunitary scattering matrix from
-    `filter_matrix_gallery`; the absorption is a 10-band graphic EQ
-    (`absorption_geq`, 11 biquad sections per delay line) targeting a
-    frequency-dependent reverberation time. The two impulse responses must
-    match to numerical precision.
+    The feedback matrix is a paraunitary scattering matrix from `filter_matrix_gallery`; the absorption is a 10-band graphic EQ (`absorption_geq`, 11 biquad sections per delay line) targeting a frequency-dependent reverberation time. The two impulse responses must match to numerical precision.
 
     Reference: *{pyFDN.paper_link("Schlecht2017AccurateReverberationTime")}.*
     """)
@@ -102,9 +93,7 @@ def _(mo):
     mo.md(r"""
     ## Design GEQ absorption filters
 
-    `absorption_geq` converts the target T60 to a per-sample dB slope, fits a
-    graphic EQ, and returns one SOS cascade per delay line, shape
-    (N, 11, 6).
+    `absorption_geq` converts the target T60 to a per-sample dB slope, fits a graphic EQ, and returns one SOS cascade per delay line, shape (N, 11, 6).
     """)
     return
 
@@ -152,12 +141,7 @@ def _(mo):
     mo.md(r"""
     ## Render with both implementations
 
-    `process_fdn` filters the delay outputs block by block (`td.SOSBank`)
-    and runs the FIR feedback matrix in the time-domain recursion
-    (`td.MatrixFIR`); the FLAMO model places the same cascades as a
-    `parallelSOSFilter` behind the delays and the FIR matrix as a `Filter`
-    feedback module. FLAMO renders circularly with period `nfft`, so `nfft`
-    is chosen long enough for the tail to decay below numerical precision.
+    `process_fdn` filters the delay outputs block by block (`td.SOSBank`) and runs the FIR feedback matrix in the time-domain recursion (`td.MatrixFIR`); the FLAMO model places the same cascades as a `parallelSOSFilter` behind the delays and the FIR matrix as a `Filter` feedback module. FLAMO renders circularly with period `nfft`, so `nfft` is chosen long enough for the tail to decay below numerical precision.
     """)
     return
 
@@ -215,8 +199,7 @@ def _(mo):
     mo.md(r"""
     ## Impulse responses
 
-    The two impulse responses overlap to numerical precision (mu-law encoded
-    for visibility of the tail).
+    The two impulse responses overlap to numerical precision (mu-law encoded for visibility of the tail).
     """)
     return
 

--- a/examples/example_random_fdn_statistics.py
+++ b/examples/example_random_fdn_statistics.py
@@ -19,17 +19,14 @@ def _(mo):
     mo.md(r"""
     # Random FDN statistics
 
-    Statistics of the modal decomposition of a random FDN. The pole angles are
-    almost equidistributed on the unit circle, while the residue magnitudes are
-    spread across a large range.
+    Statistics of the modal decomposition of a random FDN. The pole angles are almost equidistributed on the unit circle, while the residue magnitudes are spread across a large range.
 
     The residue of each mode factors into
 
     $$\rho_i = \underbrace{\frac{1}{l_i^H P'(\lambda_i)\, r_i}}_{\text{undriven}}
       \cdot \underbrace{(c\, r_i)(l_i^H b)}_{\text{input/output drive}},$$
 
-    so we compare the distribution of total residues, undriven residues, and
-    the input–output drive.
+    so we compare the distribution of total residues, undriven residues, and the input–output drive.
     """)
     return
 
@@ -189,8 +186,7 @@ def _(mo):
     mo.md(r"""
     ## Residue magnitude distribution
 
-    Total residues split into the undriven part (system-intrinsic) and the
-    input/output drive. The total residue magnitudes span a wide dB range.
+    Total residues split into the undriven part (system-intrinsic) and the input/output drive. The total residue magnitudes span a wide dB range.
     """)
     return
 

--- a/examples/example_reverberation_enhancement.py
+++ b/examples/example_reverberation_enhancement.py
@@ -20,34 +20,17 @@ def _(mo):
     mo.md(r"""
     # Reverberation enhancement with a time-varying FDN
 
-    A **reverberation enhancement system** (RES) makes a room sound more
-    reverberant electroacoustically: microphones pick up the room, a reverberator
-    processes the signal, and loudspeakers play it back — adding energy to the
-    reverberant field. The catch is that the loudspeakers leak back into the
-    microphones, so the reverberator sits *inside* an acoustic feedback loop. Too
-    much loop gain and the system colours (rings) or howls; the usable gain before
-    that happens is the **maximum stable gain** (MSG).
+    A **reverberation enhancement system** (RES) makes a room sound more reverberant electroacoustically: microphones pick up the room, a reverberator processes the signal, and loudspeakers play it back — adding energy to the reverberant field. The catch is that the loudspeakers leak back into the microphones, so the reverberator sits *inside* an acoustic feedback loop. Too much loop gain and the system colours (rings) or howls; the usable gain before that happens is the **maximum stable gain** (MSG).
 
-    A **time-varying FDN** raises the MSG: by continuously modulating the feedback
-    matrix it stops any single loop mode from building up, so the same enhancement
-    can be driven harder before it rings.
+    A **time-varying FDN** raises the MSG: by continuously modulating the feedback matrix it stops any single loop mode from building up, so the same enhancement can be driven harder before it rings.
 
     This example wires up a real RES:
 
-    * `pyroomacoustics` places a performer, a listener, **6 microphones** over the
-      stage and **6 loudspeakers** over the audience, and computes every room
-      impulse response — including the loudspeaker→microphone coupling that closes
-      the loop.
-    * the reverberator is a 6-in/6-out FDN built from `pyFDN.td` operators, with
-      an optional `td.TimeVaryingMatrix` on its feedback path.
-    * the **entire** system — room paths, coupling and FDN — is assembled as a
-      single `td` operator tree and run by one `.process(source)` call. The
-      whole electroacoustic feedback loop is just a `td.Recursion` whose feedback
-      path is the room coupling and whose forward path is the FDN.
+    * `pyroomacoustics` places a performer, a listener, **6 microphones** over the stage and **6 loudspeakers** over the audience, and computes every room impulse response — including the loudspeaker→microphone coupling that closes the loop.
+    * the reverberator is a 6-in/6-out FDN built from `pyFDN.td` operators, with an optional `td.TimeVaryingMatrix` on its feedback path.
+    * the **entire** system — room paths, coupling and FDN — is assembled as a single `td` operator tree and run by one `.process(source)` call. The whole electroacoustic feedback loop is just a `td.Recursion` whose feedback path is the room coupling and whose forward path is the FDN.
 
-    We then (1) confirm the RES enhances reverberation and (2) show the
-    time-varying FDN stays stable at a loop gain where the static one already
-    rings.
+    We then (1) confirm the RES enhances reverberation and (2) show the time-varying FDN stays stable at a loop gain where the static one already rings.
     """)
     return
 
@@ -70,11 +53,7 @@ def _(mo):
     mo.md(r"""
     ## Room, stage and audience layout
 
-    A 24 × 18 × 9 m hall (≈0.6 s natural reverberation). The performer is at the
-    front of the stage and the listener sits in the audience. The 6 microphones
-    hang low over the stage apron; the 6 loudspeakers are high over the audience —
-    a separation that keeps the loudspeaker→microphone coupling modest, as a real
-    install would.
+    A 24 × 18 × 9 m hall (≈0.6 s natural reverberation). The performer is at the front of the stage and the listener sits in the audience. The 6 microphone hang low over the stage apron; the 6 loudspeakers are high over the audience — a separation that keeps the loudspeaker→microphone coupling modest, as a real install would.
     """)
     return
 
@@ -186,13 +165,7 @@ def _(mo):
     mo.md(r"""
     ## Extract the room transfer paths
 
-    From the impulse responses we pull out four filter matrices the tree needs:
-    performer→microphones (the excitation), performer→listener (dry direct),
-    loudspeaker→listener (what the RES delivers), and the 6 × 6
-    loudspeaker→microphone **coupling** that closes the loop. Each becomes a
-    `td.MatrixConvolver`. The coupling is truncated to its first ~43 ms — the
-    early part that dominates feedback colouration — because it runs inside the
-    loop, once per block; the rest use the full room responses.
+    From the impulse responses we pull out four filter matrices the tree needs: performer→microphones (the excitation), performer→listener (dry direct), loudspeaker→listener (what the RES delivers), and the 6 × 6 loudspeaker→microphone **coupling** that closes the loop. Each becomes a `td.MatrixConvolver`. The coupling is truncated to its first ~43 ms — the early part that dominates feedback colouration — because it runs inside the loop, once per block; the rest use the full room responses.
     """)
     return
 
@@ -221,7 +194,13 @@ def _(fs, np, room):
     sig_len = int(0.8 * fs)
     print(f"Peak loudspeaker->mic coupling: {np.abs(coupling).max():.3f}")
     print(f"Room RIRs: {room_taps} taps; coupling truncated to {coupling_taps} taps")
-    return coupling, sig_len, source_to_listener, source_to_mic, speaker_to_listener
+    return (
+        coupling,
+        sig_len,
+        source_to_listener,
+        source_to_mic,
+        speaker_to_listener,
+    )
 
 
 @app.cell(hide_code=True)
@@ -229,11 +208,7 @@ def _(mo):
     mo.md(r"""
     ## The reverberator: a 6×6 FDN
 
-    The reverberator maps the 6 microphones to the 6 loudspeakers through an
-    8-line FDN with frequency-dependent absorption (its own ~1.2 s decay). The
-    feedback path is either the static mixing matrix `A`, or `Series([Gain(A),
-    td.TimeVaryingMatrix(...)])` — the only change needed to make the loop
-    time-varying.
+    The reverberator maps the 6 microphones to the 6 loudspeakers through an 8-line FDN with frequency-dependent absorption (its own ~1.2 s decay). The feedback path is either the static mixing matrix `A`, or `Series([Gain(A), td.TimeVaryingMatrix(...)])` — the only change needed to make the loop time-varying.
     """)
     return
 
@@ -304,14 +279,8 @@ def _(mo):
     )
     ```
 
-    The feedback loop `loudspeaker → room → mic → FDN → loudspeaker` is literally
-    a `td.Recursion`. A short `Delay` (the RES processing latency, ~5 ms) leads
-    its forward path, which is what lets the block recursion break the loop — the
-    same role the FDN's own delays play inside the FDN. A `Recursion` processes
-    `block_size` samples at a time and so inserts that many samples of delay into
-    its loop, which is why the latency delay (and, inside the FDN, the delay
-    lines) is shortened by exactly one block. One `.process(source)` runs the
-    whole system.
+    The feedback loop `loudspeaker → room → mic → FDN → loudspeaker` is literally a `td.Recursion`. A short `Delay` (the RES processing latency, ~5 ms) leads its forward path, which is what lets the block recursion break the loop — the same role the FDN's own delays play inside the FDN. A `Recursion` processes `block_size` samples at a time and so inserts that many samples of delay into
+    its loop, which is why the latency delay (and, inside the FDN, the delay lines) is shortened by exactly one block. One `.process(source)` runs the whole system.
     """)
     return
 
@@ -369,9 +338,7 @@ def _(mo):
     mo.md(r"""
     ## 1. Reverberation enhancement
 
-    At a comfortable loop gain the RES adds a long reverberant tail to the dry
-    response — the energy decay curve at the listener decays far more slowly with
-    the system on.
+    At a comfortable loop gain the RES adds a long reverberant tail to the dry response — the energy decay curve at the listener decays far more slowly with the system on.
     """)
     return
 
@@ -415,7 +382,7 @@ def _(fs, go, np, render):
         height=380,
     )
     fig_edc.show()
-    return (edc_db,)
+    return
 
 
 @app.cell(hide_code=True)
@@ -423,11 +390,7 @@ def _(mo):
     mo.md(r"""
     ## 2. Maximum stable gain: static vs time-varying
 
-    Now push the loop gain up. We track the short-time energy envelope of the
-    listener response: a stable (well-enhanced) system **decays**, an
-    over-driven one **grows** as a loop mode regenerates. At the same high gain
-    the static FDN is already growing (ringing), while the time-varying FDN still
-    decays — its modulation breaks up the runaway mode.
+    Now push the loop gain up. We track the short-time energy envelope of the listener response: a stable (well-enhanced) system **decays**, an over-driven one **grows** as a loop mode regenerates. At the same high gain the static FDN is already growing (ringing), while the time-varying FDN still decays — its modulation breaks up the runaway mode.
     """)
     return
 
@@ -477,7 +440,7 @@ def _(fs, go, np, render):
         height=380,
     )
     fig_msg.show()
-    return (g_challenge,)
+    return
 
 
 @app.cell(hide_code=True)
@@ -485,10 +448,7 @@ def _(mo):
     mo.md(r"""
     ## 3. The stability margin
 
-    Sweeping the loop gain makes the gain in maximum stable gain explicit: the
-    growth ratio crosses 1 (the stability boundary) at a higher gain for the
-    time-varying FDN. The horizontal distance between the two crossings is the
-    extra gain — a few dB — that time variation buys.
+    Sweeping the loop gain makes the gain in maximum stable gain explicit: the growth ratio crosses 1 (the stability boundary) at a higher gain for the time-varying FDN. The horizontal distance between the two crossings is the extra gain — a few dB — that time variation buys.
     """)
     return
 

--- a/examples/example_rir_to_fdn.py
+++ b/examples/example_rir_to_fdn.py
@@ -21,23 +21,16 @@ def _(mo, pyFDN):
     mo.md(f"""
     # Converting a room impulse response into an FDN
 
-    Estimates the frequency-dependent decay of a measured room impulse
-    response and designs an FDN to match it:
+    Estimates the frequency-dependent decay of a measured room impulse response and designs an FDN to match it:
 
     1. Estimate RT and initial level in octave bands from the RIR.
     2. Design per-delay-line GEQ absorption filters matching the decay.
     3. Design an output GEQ matching the initial spectral level.
     4. Compare the FDN impulse response with the target RIR.
 
-    The impulse response is from the Promenadikeskus concert hall in Pori,
-    Finland, published at
-    {pyFDN.paper_link("Concert_Hall_Impulse_Responses")}.
+    The impulse response is from the Promenadikeskus concert hall in Pori, Finland, published at {pyFDN.paper_link("Concert_Hall_Impulse_Responses")}.
 
-    Decay parameters are estimated with `estimate_rt_bands` (Schroeder backward integration per
-    octave band) and `estimate_initial_level_bands` (band energy matched to an
-    exponential decay model).  The output EQ is designed from the *difference*
-    between the target and the unequalized FDN band levels, which makes the
-    level match self-correcting.
+    Decay parameters are estimated with `estimate_rt_bands` (Schroeder backward integration per octave band) and `estimate_initial_level_bands` (band energy matched to an exponential decay model). The output EQ is designed from the *difference* between the target and the unequalized FDN band levels, which makes the level match self-correcting.
 
     """)
     return
@@ -109,10 +102,7 @@ def _(mo):
     mo.md(r"""
     ## Define FDN and absorption filters
 
-    A 16-delay FDN with a random orthogonal feedback matrix.  The target RT
-    at the 10 GEQ design bands (DC, 63 Hz … 8 kHz, Nyquist) extends the octave
-    band estimates, shortening the lowest and the two highest bands (air and
-    boundary absorption shortens the decay at the spectral edges).
+    A 16-delay FDN with a random orthogonal feedback matrix. The target RT at the 10 GEQ design bands (DC, 63 Hz … 8 kHz, Nyquist) extends the octave band estimates, shortening the lowest and the two highest bands (air and boundary absorption shortens the decay at the spectral edges).
     """)
     return
 
@@ -155,10 +145,7 @@ def _(mo):
     mo.md(r"""
     ## Compute the unequalized FDN impulse response
 
-    The absorption filters sit in the recursion loop of a FLAMO model
-    (input → B → [delays → SOS → A] → C → output).  This first model has no
-    output equalizer yet; its impulse response provides the reference level
-    for the EQ design.
+    The absorption filters sit in the recursion loop of a FLAMO model (input → B → [delays → SOS → A] → C → output). This first model has no output equalizer yet; its impulse response provides the reference level for the EQ design.
     """)
     return
 
@@ -198,14 +185,9 @@ def _(mo):
     mo.md(r"""
     ## Output equalization
 
-    The initial level of the unequalized FDN is roughly flat; an output GEQ
-    shapes it to the spectral envelope of the target RIR.  The GEQ target is
-    the band-wise dB difference between target and FDN initial levels, with
-    extra attenuation at the extrapolated DC and Nyquist bands.
+    The initial level of the unequalized FDN is roughly flat; an output GEQ shapes it to the spectral envelope of the target RIR. The GEQ target is the band-wise dB difference between target and FDN initial levels, with extra attenuation at the extrapolated DC and Nyquist bands.
 
-    The equalizer is placed at the end of the FLAMO graph (`output_filter`),
-    so the final model renders the complete RIR in one pass:
-    input → B → [delays → SOS → A] → C → GEQ → output.
+    The equalizer is placed at the end of the FLAMO graph (`output_filter`), so the final model renders the complete RIR in one pass: input → B → [delays → SOS → A] → C → GEQ → output.
     """)
     return
 
@@ -322,8 +304,7 @@ def _(mo):
     mo.md(r"""
     ## Reverberation time and initial level match
 
-    Estimate the decay parameters of the FDN impulse response with the same
-    estimator and compare with the target RIR.
+    Estimate the decay parameters of the FDN impulse response with the same estimator and compare with the target RIR.
     """)
     return
 
@@ -388,8 +369,7 @@ def _(mo):
     mo.md(r"""
     ## Test: reverberation time accuracy
 
-    The FDN reverberation time should be within 20% of the target in every
-    octave band (the two highest bands were deliberately shortened by design).
+    The FDN reverberation time should be within 20% of the target in every octave band (the two highest bands were deliberately shortened by design).
     """)
     return
 

--- a/examples/example_scattering_fdn.py
+++ b/examples/example_scattering_fdn.py
@@ -20,22 +20,18 @@ def _(mo, pyFDN):
     mo.md(f"""
     # Scattering feedback matrices
 
-    Demonstration of different types of scattering (FIR paraunitary) feedback
-    matrices from `filter_matrix_gallery`:
+    Demonstration of different types of scattering (FIR paraunitary) feedback matrices from `filter_matrix_gallery`:
 
     - **RandomDense** — dense cascaded paraunitary matrix;
     - **Velvet** — sparse velvet-noise feedback matrix;
     - **FromElementals** — cascade of degree-one lossless factors;
     - **NoScatter** — plain static orthogonal matrix (for comparison).
 
-    Validation is performed with the normalized echo density measure
-    (Abel & Huang 2006): scattering matrices build up echo density much faster
-    than the static matrix.
+    Validation is performed with the normalized echo density measure (Abel & Huang 2006): scattering matrices build up echo density much faster than the static matrix.
 
     Reference: *{pyFDN.paper_link("Scattering_in_Feedback_Delay_Networks")}*.
 
     """)
-
     return
 
 
@@ -101,8 +97,7 @@ def _(mo):
     mo.md(r"""
     ## Impulse responses and echo density
 
-    `process_fdn` handles the FIR feedback matrices directly in the time-domain
-    recursion (each matrix entry is an FIR filter with persistent state).
+    `process_fdn` handles the FIR feedback matrices directly in the time-domain recursion (each matrix entry is an FIR filter with persistent state).
     """)
     return
 
@@ -134,9 +129,7 @@ def _(mo):
     mo.md(r"""
     ## Plot
 
-    Solid: impulse responses (offset per type). Dashed: normalized echo
-    density profiles. The scattering matrices reach echo density 1 (Gaussian)
-    long before the static matrix.
+    Solid: impulse responses (offset per type). Dashed: normalized echo density profiles. The scattering matrices reach echo density 1 (Gaussian) long before the static matrix.
     """)
     return
 

--- a/examples/example_spread_fdn_poles.py
+++ b/examples/example_spread_fdn_poles.py
@@ -19,16 +19,12 @@ def _(mo):
     mo.md(r"""
     # FDN with spread modal decay
 
-    Demonstrates an FDN *without* homogeneous decay, but with a certain decay
-    spread, as is typically observed in shoebox rooms and scattering delay
-    networks. The spread is evaluated via the modal decomposition.
+    Demonstrates an FDN *without* homogeneous decay, but with a certain decay spread, as is typically observed in shoebox rooms and scattering delay networks. The spread is evaluated via the modal decomposition.
 
     Two feedback matrices with identical gain-per-sample energy:
 
-    - **Proportional**: $A = Q\,\Gamma$ with orthogonal $Q$ and delay-proportional
-      gains $\Gamma = \mathrm{diag}(g^{m_i})$ → all modes decay with the same T60.
-    - **Spread**: $A = Q_1\,\Gamma\,Q_2$ → the second rotation distributes the
-      absorption unevenly over the modes, spreading their T60s.
+    - **Proportional**: $A = Q\,\Gamma$ with orthogonal $Q$ and delay-proportional gains $\Gamma = \mathrm{diag}(g^{m_i})$ → all modes decay with the same T60.
+    - **Spread**: $A = Q_1\,\Gamma\,Q_2$ → the second rotation distributes the absorption unevenly over the modes, spreading their T60s.
     """)
     return
 
@@ -104,9 +100,7 @@ def _(mo):
     mo.md(r"""
     ## Modal decomposition, impulse response, energy decay curve
 
-    For each matrix type, compute poles/residues with `dss_to_pr`,
-    synthesize the impulse response from the modes with `pr_to_impz`, and
-    compute the energy decay curve.
+    For each matrix type, compute poles/residues with `dss_to_pr`, synthesize the impulse response from the modes with `pr_to_impz`, and compute the energy decay curve.
     """)
     return
 
@@ -142,8 +136,7 @@ def _(mo):
     mo.md(r"""
     ## Energy decay curves
 
-    The proportional FDN decays along a straight line; the spread FDN bends,
-    because slowly decaying modes dominate the late tail.
+    The proportional FDN decays along a straight line; the spread FDN bends, because slowly decaying modes dominate the late tail.
     """)
     return
 
@@ -170,8 +163,7 @@ def _(mo):
     mo.md(r"""
     ## Pole T60s
 
-    Per-mode reverberation time over pole angle. The proportional matrix puts
-    all poles on a single T60 line; the spread matrix scatters them.
+    Per-mode reverberation time over pole angle. The proportional matrix puts all poles on a single T60 line; the spread matrix scatters them.
     """)
     return
 

--- a/examples/example_time_varying_fdn.py
+++ b/examples/example_time_varying_fdn.py
@@ -25,9 +25,9 @@ def _(mo):
 @app.cell
 def _(mo, pyFDN):
     mo.md(f"""
-    Example for time-varying matrices. <br/>
-    Process a musical sound with a time-varying FDN reverberation. Different
-    options include slow and fast time-variation.
+    Example for time-varying matrices.
+
+    Process a musical sound with a time-varying FDN reverberation. Different options include slow and fast time-variation.
 
     Reference: *{pyFDN.paper_link("Schlecht2015PracticalConsiderationsTimevarying")}*. <br/>
     Reference: *{pyFDN.paper_link("Schlecht2015TimevaryingFeedbackMatrices")}*.

--- a/examples/example_tradeoff.py
+++ b/examples/example_tradeoff.py
@@ -19,15 +19,12 @@ def _(mo):
     mo.md(r"""
     # FDN design tradeoff
 
-    FDN design typically needs to balance modal and echo density with
-    computational complexity:
+    FDN design typically needs to balance modal and echo density with computational complexity:
 
     - the longer the delays, the more modes, but less echo density;
     - the more delays, the higher modal and echo density, but more expensive.
 
-    We compare a 3×3 grid of settings: FDN size $N \in \{4, 8, 16\}$ and
-    short/medium/long delays. Echo density (Abel & Huang 2006) makes the
-    tradeoff visible: small $N$ with long delays stays sparse for a long time.
+    We compare a 3×3 grid of settings: FDN size $N \in \{4, 8, 16\}$ and short/medium/long delays. Echo density (Abel & Huang 2006) makes the tradeoff visible: small $N$ with long delays stays sparse for a long time.
     """)
     return
 
@@ -58,8 +55,7 @@ def _(mo):
     mo.md(r"""
     ## Parameters
 
-    All settings share the same homogeneous decay (RT = 2 s), so the only
-    differences are mode count and reflection density.
+    All settings share the same homogeneous decay (RT = 2 s), so the only differences are mode count and reflection density.
     """)
     return
 
@@ -86,9 +82,7 @@ def _(mo):
     mo.md(r"""
     ## Generate impulse responses
 
-    For each combination, an orthogonal feedback matrix is scaled by the
-    delay-proportional gains (homogeneous decay), and the impulse response is
-    computed with `dss_to_impz`.
+    For each combination, an orthogonal feedback matrix is scaled by the delay-proportional gains (homogeneous decay), and the impulse response is computed with `dss_to_impz`.
     """)
     return
 
@@ -125,11 +119,7 @@ def _(mo):
     mo.md(r"""
     ## Impulse responses and echo density
 
-    Each panel shows the impulse response (gray) and its normalized echo
-    density profile (red). An echo density of 1 means the response is
-    indistinguishable from Gaussian noise (fully mixed). Down a column,
-    longer delays slow down the echo density buildup; across a row, larger
-    $N$ speeds it up.
+    Each panel shows the impulse response (gray) and its normalized echo density profile (red). An echo density of 1 means the response is indistinguishable from Gaussian noise (fully mixed). Down a column, longer delays slow down the echo density buildup; across a row, larger $N$ speeds it up.
     """)
     return
 
@@ -193,9 +183,7 @@ def _(mo):
     mo.md(r"""
     ## Listen
 
-    The perceptual difference is most obvious for the small-$N$ / long-delay
-    setting (flutter echoes) versus the large-$N$ / short-delay setting
-    (smooth reverberation).
+    The perceptual difference is most obvious for the small-$N$ / long-delay setting (flutter echoes) versus the large-$N$ / short-delay setting (smooth reverberation).
     """)
     return
 

--- a/src/pyFDN/auxiliary/coupled_rooms.py
+++ b/src/pyFDN/auxiliary/coupled_rooms.py
@@ -17,7 +17,7 @@ from pyFDN.auxiliary.tiny_rotation_matrix import tiny_rotation_matrix
 
 def create_coupled_rooms_fdn():
     """
-    Create a coupled rooms FDN matching the MATLAB implementation.
+    Create a coupled rooms FDN.
 
     This function builds a 12-delay-line FDN modeling two acoustically
     coupled rooms with different reverberation characteristics.
@@ -35,7 +35,7 @@ def create_coupled_rooms_fdn():
         >>> ir.shape
         (96000, 2)
     """
-    # Parameters (matching MATLAB exactly)
+    # Parameters
     fs = 48000
     impulse_response_length = fs * 2  # 2 seconds
     nfft = 16384
@@ -50,14 +50,14 @@ def create_coupled_rooms_fdn():
     device = "cuda" if torch.cuda.is_available() else "cpu"
     alias_decay_db = 0  # No anti-aliasing for exact reproduction
 
-    # Exact delay values from MATLAB with rng(5)
+    # Exact delay values
     delays_room1 = torch.tensor([411, 736, 403, 760, 544, 606], dtype=torch.float32)
     delays_room2 = torch.tensor(
         [2532, 2037, 1593, 1375, 1161, 2477], dtype=torch.float32
     )
     delay_lengths = torch.cat([delays_room1, delays_room2])
 
-    # Coupling parameter (exact from MATLAB)
+    # Coupling parameter
     coupling = 0.3
 
     # Generate feedback matrices using tinyRotationMatrix
@@ -130,7 +130,7 @@ def create_coupled_rooms_fdn():
     )
     mixing_matrix.assign_value(feedback_matrix)
 
-    # T60 values from MATLAB (at 1kHz)
+    # T60 values
     short_rt = torch.tensor(
         [0.5, 0.5, 0.55, 0.575, 0.525, 0.375, 0.275, 0.2, 0.175, 0.175]
     )

--- a/src/pyFDN/auxiliary/utils.py
+++ b/src/pyFDN/auxiliary/utils.py
@@ -13,7 +13,7 @@ from scipy.signal import freqz, group_delay
 
 
 def skew(X: ArrayLike) -> np.ndarray:
-    """Return skew-symmetric matrix from upper triangle (Matlab skew convention).
+    """Return skew-symmetric matrix from upper triangle.
 
     Y = triu(X, 1) - triu(X, 1).T so that Y is skew-symmetric. Equivalent to
     skew.m: Y = X - X' with X = triu(X, 1).

--- a/src/pyFDN/process.py
+++ b/src/pyFDN/process.py
@@ -24,7 +24,7 @@ def process_fdn(
 ) -> np.ndarray:
     """Simulate the feedback delay network using block processing.
 
-    Recursion per block (same ordering as the MATLAB ``processFDN``):
+    Recursion per block:
     delay output -> optional post-delay filter -> output gains C, and in the feedback
     path: absorbed delay output -> feedback matrix A -> optional post-matrix filter -> + B input.
     The wet signal is processed with an optional post-output filter before being added to the direct signal.

--- a/src/pyFDN/translate/dss_to_flamo.py
+++ b/src/pyFDN/translate/dss_to_flamo.py
@@ -76,8 +76,7 @@ def dss_to_flamo(
         Optional SOS filter in the loop after delays.
     output_filter : (n_sections, 6, num_out) array or None
         Optional SOS filter cascade applied per output channel after the
-        output gain C (e.g. an output equalizer), matching the output
-        filters of the MATLAB ``dss2impz``.
+        output gain C (e.g. an output equalizer).
     post_delay_module : FLAMO module or None
         Optional module to append after the delay in the recursion (e.g. a Schroeder allpass core).
         Must have input/output size N. Loop becomes: delay -> post_delay_module -> A.

--- a/src/pyFDN/translate/impz_to_res.py
+++ b/src/pyFDN/translate/impz_to_res.py
@@ -33,7 +33,7 @@ def impz_to_res(
             "which is required by impz2res least-squares formulation"
         )
 
-    # Remove direct term and crop as in MATLAB.
+    # Remove direct term and crop
     ir_use = ir[1:impulse_response_length]
 
     t = np.arange(impulse_response_length, dtype=np.float64).reshape(-1, 1)

--- a/tests/test_auxiliary_utils.py
+++ b/tests/test_auxiliary_utils.py
@@ -259,7 +259,7 @@ def test_max_corr_shifted_negated_copy():
 
 
 def test_max_corr_unfolds_column_major():
-    # signal k corresponds to entry (k % N1, k // N1), as in MATLAB maxCorr.m
+    # signal k corresponds to entry (k % N1, k // N1).
     signals = np.zeros((2, 2, 16))
     signals[1, 0, 3] = 1.0  # column-major index 1
     signals[0, 1, 7] = 1.0  # column-major index 2


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Link the relevant issue if applicable. -->
Improve the documentation and examples presented on the website by removing unnecessary MATLAB references and cleaning up unnecessary line breaks in Markdown text.


## Changes
<!-- Brief bullet list of what changed -->
- Removed MATLAB mentions from the documentation.
- Fixed unnecessary line breaks in Markdown text within the examples.
- Reviewed the API reference and documentation presentation for consistency.

## Testing
- [x] `pytest` passes locally
- [ ] New tests added for new functionality
- [ ] Coverage not decreased (`pytest --cov=pyFDN`)

## Checklist
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Docstrings updated for any changed public API
- [ ] `HISTORY.rst` updated if this is a user-facing change
