### PR TITLE
Rebuild a loss's cached reference when the response changes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,17 @@ Unreleased
   checked first and such a system is reported as not uniallpass, instead of the
   result depending on whether LAPACK chose to warn or raise on the ill-
   conditioned solve.
+* Fix a device mismatch when a loss built for one run is used in another: every
+  loss that holds a reference impulse response (``MatchCumulativeEnergy``,
+  ``MatchEnergyDecay``, ``MatchMagnitude``, ``MatchImpulseResponse``,
+  ``MatchSpectrogram``, ``MatchMelSpectrogram``) aligned its reference once, on
+  the first response it saw, and then handed that CPU tensor to a later CUDA
+  step -- the way a notebook cell that builds the loss but does not re-run on a
+  runtime switch would hit it. The aligned reference is now keyed on the
+  response's shape, device, dtype and sample rate, and rebuilt when any of them
+  changes. ``MatchSpectrogram`` and ``MatchMelSpectrogram`` also default their
+  ``device`` to the response's rather than to the CPU, so FLAMO builds its
+  filterbanks where the model is.
 
 0.4.1 (2026-08-24)
 ------------------

--- a/src/pyFDN/train/losses/_targets.py
+++ b/src/pyFDN/train/losses/_targets.py
@@ -45,19 +45,37 @@ def align_target(target: Any, response: Response) -> torch.Tensor:
     return torch.as_tensor(aligned, device=response.h.device, dtype=response.h.dtype)
 
 
+def response_key(response: Response) -> tuple[Any, ...]:
+    """What a loss's cached reference is only valid for.
+
+    Anything derived from a target is aligned to one response's shape, device
+    and dtype. Those hold still within a run, so caching is worth it -- but a
+    loss object outlives the run that built it, and the next one may be on a
+    different device (a notebook cell re-run on a GPU is the usual way) or at a
+    different ``nfft``. Caches key on this and rebuild when it changes, rather
+    than handing back a CPU tensor to a CUDA step.
+    """
+    h = response.h
+    return (tuple(h.shape), h.device, h.dtype, response.fs)
+
+
 class _CachedTarget:
-    """Aligns a target once, on the first response it sees.
+    """Aligns a target once per response shape/device/dtype it sees.
 
     The alignment needs the response's length, device and dtype, which are only
-    known at the first step -- but they do not change after it, so the loss
-    holds the raw target and converts lazily.
+    known at the first step -- and do not change within a run -- so the loss
+    holds the raw target and converts lazily, re-aligning if it is later called
+    on a response that no longer matches.
     """
 
     def __init__(self, target: Any) -> None:
         self._raw = target
         self._aligned: torch.Tensor | None = None
+        self._key: tuple[Any, ...] | None = None
 
     def __call__(self, response: Response) -> torch.Tensor:
-        if self._aligned is None:
+        key = response_key(response)
+        if self._aligned is None or self._key != key:
             self._aligned = align_target(self._raw, response)
+            self._key = key
         return self._aligned

--- a/src/pyFDN/train/losses/spectral.py
+++ b/src/pyFDN/train/losses/spectral.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any, Literal
 
-from ._targets import _CachedTarget
+from ._targets import _CachedTarget, response_key
 from .base import ResponseLoss
 
 if TYPE_CHECKING:
@@ -309,12 +309,24 @@ class _FlamoSpectrogramLoss(ResponseLoss):
         self.kwargs = kwargs
         self._target = _CachedTarget(target)
         self._criterion: Any = None
+        self._key: tuple[Any, ...] | None = None
 
     def _build_criterion(self, response: Response) -> Any:
         raise NotImplementedError
 
+    def _criterion_device(self, response: Response) -> Any:
+        """Where FLAMO should put its filterbanks.
+
+        FLAMO rebuilds them per call and moves them to the device it was given,
+        so an unset ``device`` has to follow the response rather than stay on
+        the CPU the loss was constructed on.
+        """
+        return response.h.device if self.device is None else self.device
+
     def __call__(self, response: Response) -> torch.Tensor:
-        if self._criterion is None:
+        key = response_key(response)
+        if self._criterion is None or self._key != key:
+            self._key = key
             self._criterion = self._build_criterion(response)
         reference = self._target(response)
         # FLAMO's spectrogram losses take (batch, n_samples, n_channels).
@@ -337,7 +349,7 @@ class MatchSpectrogram(_FlamoSpectrogramLoss):
         return mss_loss(
             nfft=list(self.nfft),
             sample_rate=int(response.fs),
-            device=self.device,
+            device=self._criterion_device(response),
             **self.kwargs,
         )
 
@@ -351,6 +363,6 @@ class MatchMelSpectrogram(_FlamoSpectrogramLoss):
         return mel_mss_loss(
             nfft=list(self.nfft),
             sample_rate=int(response.fs),
-            device=self.device,
+            device=self._criterion_device(response),
             **self.kwargs,
         )

--- a/src/pyFDN/train/losses/temporal.py
+++ b/src/pyFDN/train/losses/temporal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ._targets import _CachedTarget
+from ._targets import _CachedTarget, response_key
 from .base import ResponseLoss
 
 if TYPE_CHECKING:
@@ -111,6 +111,7 @@ class MatchEnergyDecay(ResponseLoss):
         self.floor_db = float(floor_db)
         self._target = _CachedTarget(target)
         self._reference: torch.Tensor | None = None
+        self._key: tuple[Any, ...] | None = None
         self._mask: torch.Tensor | None = None
 
     def check(self, model: Any) -> None:
@@ -155,7 +156,9 @@ class MatchEnergyDecay(ResponseLoss):
     def __call__(self, response: Response) -> torch.Tensor:
         import torch
 
-        if self._reference is None:
+        key = response_key(response)
+        if self._reference is None or self._key != key:
+            self._key = key
             self._reference = self._band_edc_db(self._target(response), response.fs)
             self._mask = self._reference > self.floor_db
             if not bool(self._mask.any()):
@@ -263,6 +266,7 @@ class MatchCumulativeEnergy(ResponseLoss):
         self._target = _CachedTarget(target)
         self._reference: list[torch.Tensor] | None = None
         self._scale: list[torch.Tensor] | None = None
+        self._key: tuple[Any, ...] | None = None
 
     def check(self, model: Any) -> None:
         nfft = int(model.nfft)
@@ -317,7 +321,9 @@ class MatchCumulativeEnergy(ResponseLoss):
         import torch
 
         # Both are set together, and mypy needs the guard to say so.
-        if self._reference is None or self._scale is None:
+        key = response_key(response)
+        if self._reference is None or self._scale is None or self._key != key:
+            self._key = key
             references = self._surfaces(self._target(response))
             # The largest value on a surface is the total energy: everything
             # after frame 0, on whichever side of the spectrum the cumulation

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1457,3 +1457,39 @@ def test_one_pole_and_the_shelf_are_told_apart_by_name_not_by_length():
     designed = pyFDN.decay_to_one_pole(1.5, 0.6, build.delays, build.fs)
     trained = param(one_pole_model, "post_delay").value().detach().numpy()
     np.testing.assert_allclose(trained, designed, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "make_loss",
+    [
+        lambda ref: MatchCumulativeEnergy(ref, window=512),
+        lambda ref: MatchEnergyDecay(ref, window=512),
+        lambda ref: pyFDN.MatchMagnitude(ref),
+        lambda ref: pyFDN.MatchImpulseResponse(ref),
+        lambda ref: MatchSpectrogram(ref, nfft=(256,)),
+        lambda ref: pyFDN.MatchMelSpectrogram(ref, nfft=(256,)),
+    ],
+)
+def test_a_loss_reused_on_a_new_response_rebuilds_its_reference(make_loss):
+    """A loss caches its reference, but only for the response it was built for.
+
+    Reusing one loss object across runs is the normal way a notebook cell works,
+    and the second run may be at another length, dtype or device -- a GPU run
+    after a CPU one used to hand a CPU reference to a CUDA step.
+    """
+    import torch
+
+    from pyFDN.train import Response
+
+    fs = 48000.0
+    rng = np.random.default_rng(7)
+    reference = _decaying_noise(2**13, fs, 0.4, rng)
+    ir = _decaying_noise(2**13, fs, 0.3, rng)
+
+    loss = make_loss(reference)
+    float(loss(Response(h=_as_h(ir), fs=fs)))  # caches against this response
+
+    # Longer, and in another dtype: a fresh loss is the ground truth.
+    long_ir = np.concatenate([ir, np.zeros(2**12)])
+    moved = Response(h=_as_h(long_ir).to(torch.float64), fs=fs)
+    assert float(loss(moved)) == pytest.approx(float(make_loss(reference)(moved)))


### PR DESCRIPTION
## The bug

Training a loss on a GPU after it had already been called on the CPU raised:

```
File "pyFDN/train/losses/temporal.py", line 342, in __call__
  torch.sqrt(((self._compressed(surface, scale) - reference) ** 2).mean())
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Every loss that holds a reference impulse response aligns it lazily, on the first `Response` it sees, and caches the result; `MatchCumulativeEnergy` also caches the surfaces and the normalizing scale derived from it. Nothing invalidated any of that.

The target was never the tensor on the wrong device — `align_target` already puts it on `response.h.device`. The mismatch came from the *derived* cache, which is why the traceback points at `self._compressed(surface, scale)` rather than at the target.

The usual way to hit it is a marimo cell that builds the loss but does not depend on `device`: switching the runtime to GPU re-runs the model and training cells, and leaves the loss object — and its CPU reference — untouched.

## The fix

Key the caches on `(shape, device, dtype, fs)` of the response and rebuild when any of them changes. The target stays plain numpy, which is what lets one loss object serve a CPU run and a GPU run.

`MatchSpectrogram` and `MatchMelSpectrogram` also default their `device` to the response's rather than to the CPU. FLAMO rebuilds its filterbanks on every call and does `.to(self.device)`, so an unset `device` left a mel filterbank on the CPU — `MatchMelSpectrogram` was broken on a GPU too, independently of the caching bug.

Affects `MatchCumulativeEnergy`, `MatchEnergyDecay`, `MatchMagnitude`, `MatchImpulseResponse`, `MatchSpectrogram`, `MatchMelSpectrogram`.

## Testing

- New parametrized `test_a_loss_reused_on_a_new_response_rebuilds_its_reference` covers all six losses: all six fail before the fix, all six pass after.
- Verified on MPS: with a CPU call followed by an MPS call on the same loss object, all six cross the device boundary and agree with a freshly built loss to within 1e-4. This is the error's own failure mode (`... found at least two devices, mps:0 and cpu!`) on the GPU backend available here.
- Full suite: 404 passed, 1 skipped. ruff, ruff-format and mypy clean.

Not yet exercised on CUDA specifically — the device handling is backend-agnostic, but the CUDA path is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KjbwqqvC44qPzxZGW1vJn
