### PR TITLE
Add Kronecker feedback matrices and a time-varying Kronecker operator

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,35 @@
 History
 =======
 
+Unreleased
+----------
+
+* Add the Kronecker feedback matrix of Coppola (DAFx26): ``kronecker_matrix``
+  builds a lossless ``2**M x 2**M`` matrix from ``M`` two-by-two rotation or
+  reflection kernels, one angle each, and ``kronecker_transform`` applies it in
+  ``O(N log2 N)`` with the paper's in-place butterfly instead of a dense
+  product. Every kernel angle addresses one bit of the delay-line index, so a
+  single angle cuts or re-couples the network along one partition -- the
+  outermost across the two stereo halves, the innermost between the even- and
+  odd-indexed lines -- and the matrix stays orthogonal at every setting. All
+  reflection kernels at ``pi/4`` recover the normalised Hadamard matrix, so the
+  usual FDN mixing matrix is one point in the family. Reachable from the
+  gallery as ``fdn_matrix_gallery(N, "kronecker")``, with ``kronecker_angles``
+  for naming the angles to move.
+* Add the ``td.KroneckerMatrix`` and ``td.TimeVaryingKroneckerMatrix``
+  operators. The latter modulates chosen kernel angles by a sine or triangle,
+  which breaks up fixed modal resonances by moving the poles without the
+  chorusing that modulating the delay lengths brings; since only one two-by-two
+  kernel changes per moving angle, per-sample modulation costs no more than the
+  static matrix. Both go straight into the ``post_matrix`` hook of
+  ``process_fdn``.
+* Add the ``example_kronecker_matrix`` notebook, which reproduces the
+  configurations from the paper's companion site: the construction and its
+  Hadamard special case, the fast transform, the stereo cross-coupling sweep on
+  the outermost angle with its interchannel-balance and IACC analysis, and
+  matrix modulation on the next angle in, with the pole-frequency histogram
+  that shows why it reduces coloration.
+
 0.4.2 (2026-08-27)
 ------------------
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -40,6 +40,11 @@ Matrix Generators
    pyFDN.construct_velvet_feedback_matrix
    pyFDN.tiny_rotation_matrix
    pyFDN.rotation_matrix_from_angles
+   pyFDN.rotation_kernel
+   pyFDN.reflection_kernel
+   pyFDN.kronecker_angles
+   pyFDN.kronecker_matrix
+   pyFDN.kronecker_transform
    pyFDN.fdn_matrix_gallery
    pyFDN.fdn_system_gallery
    pyFDN.filter_matrix_gallery
@@ -150,7 +155,9 @@ rendered with ``.process(signal)``. See :mod:`pyFDN.td`.
    pyFDN.td.SOSBank
    pyFDN.td.MatrixFIR
    pyFDN.td.MatrixConvolver
+   pyFDN.td.KroneckerMatrix
    pyFDN.td.TimeVaryingMatrix
+   pyFDN.td.TimeVaryingKroneckerMatrix
    pyFDN.td.RecursionState
    pyFDN.td.Series
    pyFDN.td.Parallel

--- a/examples/example_kronecker_matrix.py
+++ b/examples/example_kronecker_matrix.py
@@ -1,0 +1,820 @@
+# gallery_category: Feedback Matrices
+# gallery_description: Build lossless feedback matrices from Kronecker products of 2x2 kernels, then use single kernel angles to control stereo cross-coupling and time-varying modulation.
+
+import marimo
+
+__generated_with = "0.23.9"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Kronecker feedback matrices
+
+    A feedback matrix has to be orthogonal to keep an FDN lossless, and that is normally the end of the story: pick Hadamard, pick a random orthogonal matrix, and leave it alone. Nudging one entry breaks orthogonality, so there is nothing to turn.
+
+    The Kronecker construction gives the matrix knobs. An \(N \times N\) matrix with \(N = 2^M\) is written as a Kronecker product of \(M\) two-by-two kernels, each carrying one angle:
+
+    $$\Psi_M = K_M \otimes K_{M-1} \otimes \dots \otimes K_1, \qquad K_i = \mathrm{Rot}(\theta_i) \ \text{or}\ \widehat{\mathrm{Ref}}(\theta_i).$$
+
+    Kronecker products of orthogonal matrices are orthogonal, so **every** setting of every angle is lossless — the angles can be swept, modulated at audio rate, or automated, and the FDN never stops being energy-preserving.
+
+    What makes the angles useful rather than merely safe is that each one addresses one bit of the delay-line index. \(\theta_M\) mixes the two contiguous halves of the network, \(\theta_1\) mixes the even- and odd-indexed lines, and the levels in between sit at intermediate granularities. Setting one angle to zero cuts the network along that partition; sweeping it re-couples it continuously.
+
+    This notebook reproduces the configurations from the paper's companion site: the construction itself, the fast transform that applies it, the **stereo cross-coupling** sweep on \(\theta_M\), and **matrix modulation** on \(\theta_{M-1}\). The selective-freeze configuration is deliberately left out.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, pyFDN):
+    mo.md(f"""
+    Reference: *{pyFDN.paper_link("Coppola2026FastParametric")}*. <br/>
+    Companion site: <https://andrea-coppola-arturia.github.io/fastparametricmatrices/>
+    """)
+    return
+
+
+@app.cell
+def _():
+    import time
+
+    import numpy as np
+    import plotly.graph_objects as go
+    from scipy.linalg import hadamard
+    from scipy.signal import correlate, square
+
+    import pyFDN
+    from pyFDN import td
+
+    fs = 48000
+
+    # Length of every rendered listening example. Three stereo players of this
+    # length is about 6 MB of cell output, inside marimo's 8 MB default cap
+    # (``output_max_bytes``); six 6-second players would be over twice that.
+    AUDIO_SECONDS = 4.0
+    return AUDIO_SECONDS, correlate, fs, go, hadamard, np, pyFDN, square, td, time
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 1. The construction
+
+    Both kernel families are one-parameter families of 2x2 orthogonal matrices:
+
+    $$\mathrm{Rot}(\theta) = \begin{bmatrix}\cos\theta & -\sin\theta\\ \sin\theta & \cos\theta\end{bmatrix},
+    \qquad
+    \widehat{\mathrm{Ref}}(\theta) = \begin{bmatrix}\cos\theta & \sin\theta\\ \sin\theta & -\cos\theta\end{bmatrix}.$$
+
+    `pyFDN.kronecker_matrix` takes the angles innermost first — `angles[0]` is \(\theta_1\), `angles[-1]` is \(\theta_M\) — and folds them up with the recursion \(\Psi_m = K_m \otimes \Psi_{m-1}\). `pyFDN.kronecker_angles` is the convenience that fills in a default for every kernel and lets you name the ones you want to move.
+    """)
+    return
+
+
+@app.cell
+def _(np, pyFDN):
+    # Figure 5 of the paper: N = 8, rotation kernels, theta = (0, pi/4, pi/8).
+    figure5 = pyFDN.kronecker_matrix([0.0, np.pi / 4, np.pi / 8], "rotation")
+
+    print(f"orthogonal: {np.allclose(figure5 @ figure5.T, np.eye(8))}")
+    print(np.round(figure5, 2))
+    return (figure5,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Two partitions are visible at once in that matrix. \(\theta_1 = 0\) leaves the innermost kernel at the identity, so no even-indexed line ever feeds an odd-indexed one — the checkerboard of zeros. \(\theta_3 = \pi/8\) is small but non-zero, so the two halves are only weakly coupled: the corner blocks are the faint \(\pm 0.27\) entries against \(\pm 0.65\) inside each half.
+
+    The two configurations are independent, which is the point of the parameterisation. A single matrix can be split even/odd *and* partially coupled across the stereo halves at the same time.
+    """)
+    return
+
+
+@app.cell
+def _(figure5, pyFDN):
+    pyFDN.plot_matrix(
+        figure5,
+        title="Kronecker matrix Ψ₃ at θ = (0, π/4, π/8)"
+        "<br><sup>θ₁ = 0 decouples even from odd; θ₃ = π/8 leaves the halves weakly coupled</sup>",
+        block_boundaries=[4],
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Hadamard is one point in the family
+
+    \(\widehat{\mathrm{Ref}}(\pi/4)\) is exactly the order-2 Hadamard matrix, so putting every kernel there recovers the standard normalised Hadamard matrix of order \(N\). The parametric family therefore contains the usual FDN mixing matrix and morphs continuously away from it — with `"rotation"` kernels at the same angle you get the same equal-magnitude mixing under a different sign pattern.
+    """)
+    return
+
+
+@app.cell
+def _(hadamard, np, pyFDN):
+    _N = 16
+    _reflection = pyFDN.kronecker_matrix(np.full(4, np.pi / 4), "reflection")
+    _rotation = pyFDN.kronecker_matrix(pyFDN.kronecker_angles(_N), "rotation")
+
+    print(
+        "all reflection kernels at π/4 == Hadamard: "
+        f"{np.allclose(_reflection, hadamard(_N) / np.sqrt(_N))}"
+    )
+    print(
+        "all rotation kernels at π/4 mix with equal magnitude: "
+        f"{np.allclose(np.abs(_rotation), 1 / np.sqrt(_N))}"
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 2. Applying it in O(N log₂ N)
+
+    The recursive structure is also a divide-and-conquer algorithm. `pyFDN.kronecker_transform` never forms the matrix: it runs \(\log_2 N\) butterfly passes over the channel vector, level \(i\) mixing the channel pairs that differ in bit \(i-1\) of their index. That is the same cost as the fast Walsh–Hadamard transform, but with \(M\) free parameters instead of none.
+
+    It matters most when the angles move. A dense matrix product has to rebuild the whole \(N \times N\) matrix whenever an angle changes; here a moving angle only changes the two-by-two kernel of one level, so per-sample modulation costs no more than a static matrix.
+    """)
+    return
+
+
+@app.cell
+def _(mo, np, pyFDN, time):
+    _rng = np.random.default_rng(0)
+    _rows = [
+        "| N | max abs. difference | dense (ms) | butterfly (ms) |",
+        "|---|---|---|---|",
+    ]
+    for _M in (3, 4, 5, 6):
+        _size = 2**_M
+        _angles = _rng.uniform(-np.pi, np.pi, _M)
+        _matrix = pyFDN.kronecker_matrix(_angles)
+        _x = _rng.standard_normal((4096, _size))
+
+        _t0 = time.perf_counter()
+        _dense = _x @ _matrix.T
+        _dense_time = time.perf_counter() - _t0
+
+        _t0 = time.perf_counter()
+        _fast = pyFDN.kronecker_transform(_x, _angles)
+        _fast_time = time.perf_counter() - _t0
+
+        _rows.append(
+            f"| {_size} | {np.abs(_dense - _fast).max():.1e} | "
+            f"{_dense_time * 1e3:.2f} | {_fast_time * 1e3:.2f} |"
+        )
+
+    mo.output.replace(mo.md("\n".join(_rows)))
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    The two agree to machine precision. The timing here is NumPy on 4096-sample blocks, where BLAS makes the dense product very hard to beat at these sizes; the paper's C++ benchmark, which multiplies one sample at a time inside a feedback loop, is where the asymptotic win shows up (7.5x over a naive product at \(N = 32\), and 24x once an angle is updated every sample).
+
+    `pyFDN.td` wraps both cases as operators: `td.KroneckerMatrix` for a fixed angle set, `td.TimeVaryingKroneckerMatrix` for modulated ones.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 3. Stereo cross-coupling on θ_M
+
+    Split the delay lines into two halves and give each half one stereo channel: the left input feeds lines 0–15 and is read back off them, the right input feeds lines 16–31. The outermost angle is then exactly the knob that decides how much the two sides hear of each other.
+
+    Writing \(\Psi_M = \mathrm{Rot}(\theta_M) \otimes \Psi_{M-1}\) out in blocks,
+
+    $$\Psi_M = \begin{bmatrix} \cos\theta_M\,\Psi_{M-1} & -\sin\theta_M\,\Psi_{M-1}\\ \sin\theta_M\,\Psi_{M-1} & \cos\theta_M\,\Psi_{M-1}\end{bmatrix},$$
+
+    so at \(\theta_M = 0\) the off-diagonal blocks vanish and the two halves are separate FDNs, at \(\theta_M = \pi/4\) all four blocks have equal weight and the network is one unified, maximally diffusive FDN, and everything in between is a continuous, always-lossless morph. The site's percentages are positions along \([0, \pi/4]\).
+
+    ### The network
+
+    A 32-line FDN, coprime delays from 20 ms to 200 ms, \(T_{60} = 10\) s, no damping filters and no diffusion stages, so nothing but the matrix shapes what is heard. The sorted delays are dealt alternately into the two halves so each half spans the full 20–200 ms range — otherwise the contiguous split would give one channel all the short lines and the other all the long ones.
+    """)
+    return
+
+
+@app.cell
+def _(fs, np, pyFDN):
+    N_stereo = 32
+    T60_stereo = 10.0  # seconds
+
+    _sorted_delays = pyFDN.sample_delay_lengths(
+        N_stereo,
+        (int(0.020 * fs), int(0.200 * fs)),
+        coprime=True,
+        sort=True,
+        rng=2026,
+    )
+    # Deal alternately into the two halves so both span 20-200 ms.
+    delays_stereo = _sorted_delays.reshape(-1, 2).T.reshape(-1)
+
+    absorption_stereo = np.diag(
+        pyFDN.rt_to_gain_per_sample(T60_stereo, fs) ** delays_stereo
+    )
+
+    # Left input drives the first half, right input the second (Eq. 19 and 20).
+    _half = N_stereo // 2
+    input_stereo = np.zeros((N_stereo, 2))
+    input_stereo[:_half, 0] = 1 / np.sqrt(_half)
+    input_stereo[_half:, 1] = 1 / np.sqrt(_half)
+    output_stereo = input_stereo.T.copy()
+    direct_stereo = np.zeros((2, 2))
+
+    print(
+        f"half A: {delays_stereo[:_half].min()}–{delays_stereo[:_half].max()} samples"
+    )
+    print(
+        f"half B: {delays_stereo[_half:].min()}–{delays_stereo[_half:].max()} samples"
+    )
+    return (
+        N_stereo,
+        absorption_stereo,
+        delays_stereo,
+        direct_stereo,
+        input_stereo,
+        output_stereo,
+    )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### The coupling sweep
+
+    Six settings, the six on the companion site: 0%, 5%, 10%, 25%, 50% and 100% of the way from \(\theta_M = 0\) to \(\theta_M = \pi/4\). Only that one angle changes; every other kernel stays at \(\pi/4\).
+    """)
+    return
+
+
+@app.cell
+def _(N_stereo, np, pyFDN):
+    coupling_percent = [0, 5, 10, 25, 50, 100]
+
+    coupling_angles = {
+        percent: pyFDN.kronecker_angles(N_stereo, theta5=np.pi / 4 * percent / 100)
+        for percent in coupling_percent
+    }
+
+    for _percent, _angles in coupling_angles.items():
+        print(f"{_percent:4d}%   θ_M = {_angles[-1]:.4f} rad")
+    return coupling_angles, coupling_percent
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Stereo impulse responses
+
+    A unit impulse into the left input only, so any energy appearing on the right had to cross through the coupling blocks.
+    """)
+    return
+
+
+@app.cell
+def _(
+    absorption_stereo,
+    coupling_angles,
+    delays_stereo,
+    direct_stereo,
+    fs,
+    input_stereo,
+    np,
+    output_stereo,
+    pyFDN,
+):
+    _ir_duration = 12.0  # seconds
+
+    _impulse = np.zeros((int(_ir_duration * fs), 2))
+    _impulse[0, 0] = 1.0
+
+    stereo_ir = {
+        percent: pyFDN.process_fdn(
+            _impulse,
+            delays_stereo,
+            pyFDN.kronecker_matrix(angles) @ absorption_stereo,
+            input_stereo,
+            output_stereo,
+            direct_stereo,
+        )
+        for percent, angles in coupling_angles.items()
+    }
+    return (stereo_ir,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Where the energy is
+
+    The most direct reading of the sweep: the level of the right channel relative to the left, in 100 ms windows. At 0% the right channel is digital silence for ever. At 5% it climbs slowly out of nothing and is still 15 dB down after ten seconds; by 25% the two sides are within a few dB after a second or so; at 100% they are level almost immediately.
+    """)
+    return
+
+
+@app.cell
+def _(coupling_percent, fs, go, mo, np, stereo_ir):
+    def channel_balance(ir, window=0.100, hop=0.050):
+        """Right-minus-left level in dB, in sliding windows."""
+        w, h = int(window * fs), int(hop * fs)
+        starts = np.arange(0, len(ir) - w, h)
+        energy_l = np.array([np.sum(ir[s : s + w, 0] ** 2) for s in starts])
+        energy_r = np.array([np.sum(ir[s : s + w, 1] ** 2) for s in starts])
+        times = (starts + w / 2) / fs
+        return times, 10 * np.log10((energy_r + 1e-30) / (energy_l + 1e-30))
+
+    _figure = go.Figure()
+    for _percent in coupling_percent:
+        _t, _balance = channel_balance(stereo_ir[_percent])
+        _figure.add_scatter(
+            x=_t, y=np.maximum(_balance, -80), mode="lines", name=f"{_percent}%"
+        )
+    _figure.update_layout(
+        title="Right-channel level relative to left"
+        "<br><sup>impulse into the left input only; floor clamped at −80 dB</sup>",
+        xaxis_title="Time [s]",
+        yaxis_title="R − L [dB]",
+        height=420,
+        legend_title="coupling",
+    )
+    mo.output.replace(_figure)
+    return (channel_balance,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Interaural cross-correlation
+
+    The site's own measure. IACC is the peak magnitude of the normalised cross-correlation between the two channels over a ±1 ms lag window, evaluated in sliding 100 ms windows: near 1 the channels are near-identical and the image is narrow and centred, near 0 they are decorrelated and the image is wide.
+
+    At 0% the right channel is silent, the correlation is undefined, and the trace is simply absent — the same gap the site leaves in that figure. Every coupled setting behaves the way the site describes: whatever the coupling strength, the reverberant tail decorrelates within a fraction of a second and settles at a low steady-state value. Coupling controls *how much* energy reaches the other side, not how similar the two sides end up sounding — that is what the balance plot above measures and this one does not.
+    """)
+    return
+
+
+@app.cell
+def _(correlate, coupling_percent, fs, go, mo, np, stereo_ir):
+    def iacc(ir, window=0.100, hop=0.050, max_lag=0.001):
+        """Sliding-window IACC (ISO 3382-1) of a stereo impulse response."""
+        w, h, lag = int(window * fs), int(hop * fs), int(max_lag * fs)
+        starts = np.arange(0, len(ir) - w, h)
+        values = np.full(len(starts), np.nan)
+        for index, start in enumerate(starts):
+            left, right = ir[start : start + w, 0], ir[start : start + w, 1]
+            norm = np.sqrt(np.sum(left**2) * np.sum(right**2))
+            if norm < 1e-20:  # a silent channel leaves the IACC undefined
+                continue
+            rho = correlate(left, right, mode="full")[w - 1 - lag : w + lag] / norm
+            values[index] = np.max(np.abs(rho))
+        return (starts + w / 2) / fs, values
+
+    _figure = go.Figure()
+    for _percent in coupling_percent:
+        _t, _values = iacc(stereo_ir[_percent])
+        if np.all(np.isnan(_values)):
+            continue  # 0%: right channel silent throughout
+        _figure.add_scatter(x=_t, y=_values, mode="lines", name=f"{_percent}%")
+    _figure.update_layout(
+        title="Sliding-window IACC"
+        "<br><sup>100 ms window, 50 ms hop, ±1 ms lag; 0% omitted (right channel silent)</sup>",
+        xaxis_title="Time [s]",
+        yaxis_title="IACC",
+        yaxis_range=[0, 1],
+        height=420,
+        legend_title="coupling",
+    )
+    mo.output.replace(_figure)
+    return (iacc,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Listen
+
+    A single piano-like note hard-panned left, rendered 100% wet through each setting. Headphones recommended. The note stays put at 0%, sweeps slowly across at 5–10%, and is spread across the panorama almost at once at 100%.
+    """)
+    return
+
+
+@app.cell
+def _(AUDIO_SECONDS, fs, mo, np, pyFDN):
+    def piano_note(f0, duration, fs, seed=0):
+        """A plucked-string-ish tone: decaying inharmonic partials plus a click."""
+        rng = np.random.default_rng(seed)
+        t = np.arange(int(duration * fs)) / fs
+        note = np.zeros_like(t)
+        for partial in range(1, 17):
+            # Slight stiffness-induced inharmonicity, and faster decay up high.
+            frequency = f0 * partial * np.sqrt(1 + 4e-4 * partial**2)
+            if frequency > 0.45 * fs:
+                break
+            note += (
+                np.exp(-t * (2.0 + 0.9 * partial))
+                * np.sin(2 * np.pi * frequency * t + rng.uniform(0, 2 * np.pi))
+                / partial**1.3
+            )
+        hammer = rng.standard_normal(len(t)) * np.exp(-t * 900) * 0.4
+        note = note + hammer
+        return note / np.abs(note).max() * 0.9
+
+    dry_note = piano_note(220.0, 1.2, fs)
+
+    # Hard-panned left, then silence for the tail. Kept to AUDIO_SECONDS so a
+    # cell of three players stays inside marimo's 8 MB output limit.
+    stereo_note = np.zeros((int(AUDIO_SECONDS * fs), 2))
+    stereo_note[: len(dry_note), 0] = dry_note
+
+    mo.output.replace(
+        pyFDN.labeled_audio(
+            "<b>Dry source: piano note, hard-panned left</b>", stereo_note, fs=fs
+        )
+    )
+    return (stereo_note,)
+
+
+@app.cell
+def _(
+    absorption_stereo,
+    coupling_angles,
+    delays_stereo,
+    direct_stereo,
+    input_stereo,
+    output_stereo,
+    pyFDN,
+    stereo_note,
+):
+    stereo_wet = {
+        percent: pyFDN.process_fdn(
+            stereo_note,
+            delays_stereo,
+            pyFDN.kronecker_matrix(angles) @ absorption_stereo,
+            input_stereo,
+            output_stereo,
+            direct_stereo,
+        )
+        for percent, angles in coupling_angles.items()
+    }
+    return (stereo_wet,)
+
+
+@app.cell
+def _(coupling_angles, fs, mo, pyFDN, stereo_wet):
+    def coupling_players(percentages):
+        """Stack the players for a few coupling settings.
+
+        Split across two cells: six stereo players in a single output would
+        exceed marimo's 8 MB per-cell limit (``output_max_bytes``).
+        """
+        return mo.vstack(
+            [
+                pyFDN.labeled_audio(
+                    f"<b>{percent}% coupling</b> — θ_M = "
+                    f"{coupling_angles[percent][-1]:.4f} rad",
+                    stereo_wet[percent],
+                    fs=fs,
+                )
+                for percent in percentages
+            ]
+        )
+
+    return (coupling_players,)
+
+
+@app.cell
+def _(coupling_percent, coupling_players, mo):
+    mo.output.replace(coupling_players(coupling_percent[:3]))
+    return
+
+
+@app.cell
+def _(coupling_percent, coupling_players, mo):
+    mo.output.replace(coupling_players(coupling_percent[3:]))
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 4. Matrix modulation on θ_{M−1}
+
+    A static FDN has fixed modes. Sustain a harmonically rich tone through one and the same handful of resonances is excited for as long as the tone lasts, which is what "metallic ringing" describes. Moving a kernel angle moves the poles, so no mode is driven long enough to stand out.
+
+    What distinguishes this from the familiar cure — modulating the delay lengths — is that the routing coefficients move while the delays stay put. Delay modulation retunes the whole network and brings chorusing with it; matrix modulation only redistributes energy between lines, so it breaks up resonances with far less pitch movement.
+
+    The site isolates the effect on a deliberately sparse network: 16 lines with \(\theta_M = 0\), which splits it into two independent 8×8 sub-networks, one per stereo side. Fewer modes per side makes the individual resonances easy to hear. With \(M = \log_2 16 = 4\), the modulated angle \(\theta_{M-1}\) is \(\theta_3\), and it follows
+
+    $$\theta_3(t) = \frac{\pi}{4} + \text{depth}\cdot\sin(2\pi\,\text{rate}\,t).$$
+    """)
+    return
+
+
+@app.cell
+def _(fs, np, pyFDN):
+    N_mod = 16
+    T60_mod = 3.0  # seconds
+
+    _sorted_delays = pyFDN.sample_delay_lengths(
+        N_mod, (int(0.020 * fs), int(0.200 * fs)), coprime=True, sort=True, rng=7
+    )
+    delays_mod = _sorted_delays.reshape(-1, 2).T.reshape(-1)
+
+    # theta_M = 0: two independent 8x8 sub-networks, one per stereo side.
+    modulation_base = pyFDN.kronecker_angles(N_mod, theta4=0.0)
+
+    absorption_mod = np.diag(pyFDN.rt_to_gain_per_sample(T60_mod, fs) ** delays_mod)
+
+    _half = N_mod // 2
+    input_mod = np.zeros((N_mod, 2))
+    input_mod[:_half, 0] = 1 / np.sqrt(_half)
+    input_mod[_half:, 1] = 1 / np.sqrt(_half)
+    output_mod = input_mod.T.copy()
+    direct_mod = np.zeros((2, 2))
+
+    print(f"base angles θ₁..θ₄: {np.round(modulation_base, 4)}")
+    return (
+        N_mod,
+        absorption_mod,
+        delays_mod,
+        direct_mod,
+        input_mod,
+        modulation_base,
+        output_mod,
+    )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### The dry source
+
+    Two sustained chords on a square-wave oscillator. The harmonically rich tone excites the network's modes hard, which is what surfaces the metallic ringing that the modulation is meant to remove.
+    """)
+    return
+
+
+@app.cell
+def _(AUDIO_SECONDS, fs, mo, np, pyFDN, square):
+    def square_chord(freqs, start, stop, t, fade=0.01):
+        """A square-wave chord gated between ``start`` and ``stop`` seconds."""
+        gate = ((t >= start) & (t < stop)).astype(float)
+        ramp = np.clip((t - start) / fade, 0, 1) * np.clip((stop - t) / fade, 0, 1)
+        tone = sum(square(2 * np.pi * f * t) for f in freqs) / len(freqs)
+        return 0.35 * tone * gate * ramp
+
+    _t = np.arange(int(AUDIO_SECONDS * fs)) / fs
+    # Two shortish chords, so that the last 1.4 s is exposed tail -- which is
+    # where the ringing the modulation removes is easiest to hear.
+    _chords = square_chord([220.0, 277.18, 329.63], 0.1, 1.3, _t) + square_chord(
+        [196.0, 246.94, 293.66], 1.5, 2.6, _t
+    )
+    dry_chords = np.stack([_chords, _chords], axis=1)
+
+    mo.output.replace(
+        pyFDN.labeled_audio(
+            "<b>Dry source: two chords (square-wave oscillator)</b>", dry_chords, fs=fs
+        )
+    )
+    return (dry_chords,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Three modulation regimes
+
+    The three settings from the site: off, the recommended subtle setting (0.2 Hz, depth 0.2π), and the aggressive upper bound (2 Hz, depth π — the full angular range).
+
+    `td.TimeVaryingKroneckerMatrix` takes the base angles plus a rate and depth per kernel; zeros leave a kernel alone, which is how a single level is singled out. With the FDN's static feedback matrix set to the absorption alone, the operator on `post_matrix` *is* the feedback matrix.
+    """)
+    return
+
+
+@app.cell
+def _(N_mod, fs, modulation_base, np, td):
+    modulation_settings = {
+        "off": (0.0, 0.0),
+        "subtle (0.2 Hz, 0.2π)": (0.2, 0.2 * np.pi),
+        "aggressive (2 Hz, π)": (2.0, np.pi),
+    }
+
+    def modulated_matrix(rate, depth):
+        """Modulate theta_{M-1} only, leaving every other kernel fixed."""
+        modulated = np.arange(int(np.log2(N_mod))) == int(np.log2(N_mod)) - 2
+        return td.TimeVaryingKroneckerMatrix(
+            modulation_base,
+            fs,
+            rate=np.where(modulated, rate, 0.0),
+            depth=np.where(modulated, depth, 0.0),
+        )
+
+    modulation_names = list(modulation_settings)
+    return modulated_matrix, modulation_names, modulation_settings
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    The angle trajectories, one second of each. The subtle setting stays within a fifth of π of centre; the aggressive one sweeps the whole range twice a second, which is audible as an effect in its own right rather than as diffusion.
+    """)
+    return
+
+
+@app.cell
+def _(fs, go, mo, modulated_matrix, modulation_settings, np):
+    _figure = go.Figure()
+    _n = np.arange(0, 3 * fs, 64)
+    for _name, (_rate, _depth) in modulation_settings.items():
+        _angles = modulated_matrix(_rate, _depth).angles_at(_n)
+        _figure.add_scatter(x=_n / fs, y=_angles[:, 2], mode="lines", name=_name)
+    _figure.update_layout(
+        title="Modulated kernel angle θ₃ = θ_{M−1}",
+        xaxis_title="Time [s]",
+        yaxis_title="θ₃ [rad]",
+        height=340,
+    )
+    mo.output.replace(_figure)
+    return
+
+
+@app.cell
+def _(
+    absorption_mod,
+    delays_mod,
+    direct_mod,
+    dry_chords,
+    input_mod,
+    modulated_matrix,
+    modulation_settings,
+    output_mod,
+    pyFDN,
+):
+    modulated_wet = {
+        name: pyFDN.process_fdn(
+            dry_chords,
+            delays_mod,
+            absorption_mod,  # A carries the absorption only ...
+            input_mod,
+            output_mod,
+            direct_mod,
+            post_matrix=modulated_matrix(rate, depth),  # ... the operator is the matrix
+        )
+        for name, (rate, depth) in modulation_settings.items()
+    }
+    return (modulated_wet,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Read the three spectrograms downwards. The static network leaves sharp horizontal ridges where individual modes sustain through the chord tails; subtle modulation smears them; the aggressive setting broadens them into wavering bands.
+    """)
+    return
+
+
+@app.cell
+def _(fs, mo, modulated_wet, modulation_names, pyFDN):
+    mo.vstack(
+        [
+            pyFDN.plot_spectrogram(
+                modulated_wet[name][:, 0],
+                fs,
+                nperseg=2048 * 8,
+                noverlap=2048 * 6,
+                title=f"Modulation {name} — spectrogram",
+                colorscale="Magma",
+                height=330,
+            )
+            for name in modulation_names
+        ]
+    )
+    return
+
+
+@app.cell
+def _(fs, mo, modulated_wet, modulation_names, pyFDN):
+    mo.output.replace(
+        mo.vstack(
+            [
+                pyFDN.labeled_audio(
+                    f"<b>Modulation {name}</b>", modulated_wet[name], fs=fs
+                )
+                for name in modulation_names
+            ]
+        )
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Why it works: the poles move
+
+    Figure 6 of the paper measures the effect on the poles directly. Freeze the modulated matrix at a sequence of instants across one modulation period, take the poles of the resulting FDN each time, and histogram their frequencies. Without modulation every snapshot has the same poles, so the histogram is a set of spikes; with modulation the poles wander and the histogram flattens. The standard deviation of the bin counts is the summary number — lower means a more uniform pole density, which is what "less coloration" means quantitatively.
+
+    The paper's network: 8 lines at `m = [53, 61, 71, 79, 89, 101, 113, 127]`, rotation kernels, and the middle angle \(\theta_2\) modulated with amplitude π by a 1 Hz triangle wave.
+    """)
+    return
+
+
+@app.cell
+def _(fs, np, pyFDN):
+    figure6_delays = np.array([53, 61, 71, 79, 89, 101, 113, 127])
+    N_figure6 = len(figure6_delays)
+    num_snapshots = 21
+
+    def pole_frequencies(angles):
+        """Positive pole frequencies in Hz of the lossless FDN at these angles."""
+        _, poles, _, _, _ = pyFDN.dss_to_pr(
+            figure6_delays,
+            pyFDN.kronecker_matrix(angles),
+            np.ones((N_figure6, 1)),
+            np.ones((1, N_figure6)),
+            np.zeros((1, 1)),
+            mode="roots",
+        )
+        frequency = np.angle(poles) / (2 * np.pi) * fs
+        return frequency[frequency > 0]
+
+    # One period of a unit-amplitude 1 Hz triangle wave.
+    _phase = 2 * np.pi * np.arange(num_snapshots) / num_snapshots
+    triangle = (2 / np.pi) * np.arcsin(np.sin(_phase))
+
+    static_poles = np.tile(
+        pole_frequencies(pyFDN.kronecker_angles(N_figure6)), num_snapshots
+    )
+    modulated_poles = np.concatenate(
+        [
+            pole_frequencies(
+                pyFDN.kronecker_angles(N_figure6, theta2=np.pi / 4 + np.pi * weight)
+            )
+            for weight in triangle
+        ]
+    )
+    return modulated_poles, num_snapshots, static_poles
+
+
+@app.cell
+def _(go, mo, modulated_poles, np, num_snapshots, static_poles):
+    _bins = np.linspace(4500, 7500, 51)
+    _centres = (_bins[:-1] + _bins[1:]) / 2
+
+    _static_counts, _ = np.histogram(static_poles, _bins)
+    _modulated_counts, _ = np.histogram(modulated_poles, _bins)
+
+    _figure = go.Figure()
+    _figure.add_bar(
+        x=_centres,
+        y=_static_counts,
+        name=f"no modulation (σ = {_static_counts.std():.1f})",
+    )
+    _figure.add_bar(
+        x=_centres,
+        y=_modulated_counts,
+        name=f"modulated (σ = {_modulated_counts.std():.1f})",
+    )
+    _figure.update_layout(
+        title="Pole frequency histogram over one modulation period"
+        f"<br><sup>{num_snapshots} snapshots of the 8×8 Kronecker FDN; σ is the standard deviation of the bin counts</sup>",
+        xaxis_title="Frequency [Hz]",
+        yaxis_title="Number of occurrences",
+        barmode="overlay",
+        height=420,
+    )
+    _figure.update_traces(opacity=0.65)
+    mo.output.replace(_figure)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Modulation roughly halves the spread of the bin counts here, the same direction and order as the paper reports (71.0 down to 24.8 on its own network and bin grid; the absolute numbers scale with the number of snapshots and bins). Fixed poles pile into a few bins and leave others empty; moving poles fill the band, and that even filling is the reverberation-tail liveliness the modulation is after.
+
+    ## What was left out
+
+    The companion site's third configuration, selective freeze on \(\theta_1 = 0\), is not covered here. It needs the input matrix and the absorption to be switched at runtime — the frozen half gets zero input and unit gain — rather than a matrix construction, so it belongs with the time-varying-gain machinery rather than with the feedback matrix itself.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/pyFDN/__init__.py
+++ b/src/pyFDN/__init__.py
@@ -71,10 +71,15 @@ __all__ = [
     "FDNSystem",
     "householder_matrix",
     "is_almost_zero",
+    "kronecker_angles",
+    "kronecker_matrix",
+    "kronecker_transform",
     "nearest_orthogonal",
     "nearest_sign_agnostic_orthogonal",
     "random_matrix_shift",
     "random_orthogonal",
+    "reflection_kernel",
+    "rotation_kernel",
     "rotation_matrix_from_angles",
     "sample_delay_lengths",
     "schroeder_reverberator",
@@ -419,6 +424,13 @@ from .generate.fdn_matrix_gallery import (
 )
 from .generate.householder_matrix import householder_matrix
 from .generate.is_almost_zero import is_almost_zero
+from .generate.kronecker_matrix import (
+    kronecker_angles,
+    kronecker_matrix,
+    kronecker_transform,
+    reflection_kernel,
+    rotation_kernel,
+)
 from .generate.nearest_orthogonal import nearest_orthogonal
 from .generate.nearest_sign_agnostic_orthogonal import nearest_sign_agnostic_orthogonal
 from .generate.random_matrix_shift import random_matrix_shift

--- a/src/pyFDN/generate/fdn_matrix_gallery.py
+++ b/src/pyFDN/generate/fdn_matrix_gallery.py
@@ -5,9 +5,11 @@ Translation of fdnMatrixGallery.m from fdnToolbox.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Literal, NamedTuple, NoReturn, get_args, overload
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 from .householder_matrix import householder_matrix
 from .random_orthogonal import random_orthogonal
@@ -36,6 +38,7 @@ def _circulant(v: np.ndarray, direction: int = 1) -> np.ndarray:
 FeedbackMatrixType = Literal[
     "orthogonal",
     "hadamard",
+    "kronecker",
     "householder",
     "circulant",
     "permutation",
@@ -183,6 +186,9 @@ def filter_matrix_gallery(
 def fdn_matrix_gallery(
     N: int | None = None,
     matrix_type: str | None = None,
+    *,
+    angles: ArrayLike | None = None,
+    kernel_type: str | Sequence[str] = "rotation",
 ) -> np.ndarray | list[str]:
     """Return a feedback matrix of the requested type, or list all type names.
 
@@ -190,6 +196,12 @@ def fdn_matrix_gallery(
         N: Matrix size.  Ignored when ``matrix_type`` is ``None``.
         matrix_type: One of the supported type strings.  Pass ``None`` (or call
                      with no arguments) to get the list of all type names.
+        angles: Kernel angles for the ``"kronecker"`` type, innermost first
+            (see :func:`pyFDN.kronecker_matrix`).  Defaults to ``pi / 4`` on
+            every kernel, the equal-mixing setting.  Ignored otherwise.
+        kernel_type: Kernel family for the ``"kronecker"`` type,
+            ``"rotation"`` or ``"reflection"``, either once for all kernels or
+            one per kernel.  Ignored otherwise.
 
     Returns:
         Feedback matrix of shape ``(N, N)``, or a list of type-name strings.
@@ -199,6 +211,7 @@ def fdn_matrix_gallery(
         fdn_matrix_gallery()             # → list of type strings
         fdn_matrix_gallery(4, "orthogonal")
         fdn_matrix_gallery(8, "hadamard")
+        fdn_matrix_gallery(8, "kronecker", angles=[0.0, np.pi / 4, np.pi / 8])
     """
     if matrix_type is None:
         return list(FEEDBACK_MATRIX_TYPES)
@@ -215,6 +228,12 @@ def fdn_matrix_gallery(
         from scipy.linalg import hadamard
 
         return hadamard(N) / np.sqrt(N)
+
+    if matrix_type == "kronecker":
+        from .kronecker_matrix import kronecker_angles, kronecker_matrix
+
+        theta = kronecker_angles(N) if angles is None else angles
+        return kronecker_matrix(theta, kernel_type)
 
     if matrix_type == "circulant":
         r_fft = np.fft.fft(np.random.randn(N))

--- a/src/pyFDN/generate/kronecker_matrix.py
+++ b/src/pyFDN/generate/kronecker_matrix.py
@@ -1,0 +1,284 @@
+"""Parametric orthogonal feedback matrices built from Kronecker products.
+
+Implementation of the Kronecker Feedback Matrix of Coppola (2026),
+``Fast parametric matrices for lossless feedback delay networks`` (DAFx26).
+
+A matrix of size ``N = 2**M`` is the Kronecker product of ``M`` independent
+2x2 orthogonal kernels, each parameterised by a single angle::
+
+    Psi_M = K_M kron K_{M-1} kron ... kron K_1
+
+with ``K_i`` either a rotation :func:`rotation_kernel` or a reflection
+:func:`reflection_kernel`.  The product of orthogonal matrices under ``kron``
+is orthogonal, so ``Psi_M`` is lossless for *every* angle -- no
+re-orthogonalisation is ever needed while the angles move.
+
+Each kernel index addresses one bit of the delay-line index, which is what
+makes the parameterisation structurally meaningful:
+
+* ``theta_M`` (outermost) mixes the two contiguous halves of the network.  At
+  ``theta_M = 0`` the halves are independent, which is the stereo
+  cross-coupling control.
+* ``theta_1`` (innermost) mixes adjacent pairs, i.e. it couples the
+  even- and odd-indexed delay lines.  At ``theta_1 = 0`` the network splits
+  into an even and an odd subnetwork.
+* Intermediate kernels are free for time-varying modulation, see
+  :class:`pyFDN.td.TimeVaryingKroneckerMatrix`.
+
+Setting every kernel to ``reflection_kernel(pi / 4)`` recovers the normalised
+Hadamard matrix, so the family contains the standard FDN mixing matrix as one
+point and morphs continuously away from it.
+
+Because the matrix is never formed, :func:`kronecker_transform` applies it in
+``O(N log2 N)`` operations instead of ``O(N**2)`` -- the same cost as the fast
+Walsh-Hadamard transform, but with ``M`` free parameters.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, get_args
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+KernelType = Literal["rotation", "reflection"]
+KERNEL_TYPES = get_args(KernelType)
+
+
+def rotation_kernel(theta: float) -> np.ndarray:
+    """2x2 rotation by ``theta``: ``[[cos, -sin], [sin, cos]]``.
+
+    ``rotation_kernel(0)`` is the identity, so a zero angle decouples the two
+    branches that the kernel addresses.
+    """
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([[c, -s], [s, c]])
+
+
+def reflection_kernel(theta: float) -> np.ndarray:
+    """2x2 reflection at half-angle ``theta``: ``[[cos, sin], [sin, -cos]]``.
+
+    Reflects across the line at ``theta / 2`` from the horizontal axis; the
+    half-angle convention keeps the parameterisation consistent with
+    :func:`rotation_kernel`.  ``reflection_kernel(pi / 4)`` is the order-2
+    Hadamard matrix ``[[1, 1], [1, -1]] / sqrt(2)``.
+    """
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([[c, s], [s, -c]])
+
+
+_KERNELS = {"rotation": rotation_kernel, "reflection": reflection_kernel}
+
+
+def _normalise_kernel_types(
+    kernel_type: str | Sequence[str], M: int
+) -> tuple[str, ...]:
+    """Broadcast ``kernel_type`` to one entry per kernel and validate it."""
+    types = (kernel_type,) * M if isinstance(kernel_type, str) else tuple(kernel_type)
+    if len(types) != M:
+        raise ValueError(
+            f"kernel_type has {len(types)} entries but there are {M} kernels"
+        )
+    for name in types:
+        if name not in _KERNELS:
+            raise ValueError(
+                f"Unknown kernel_type {name!r}. Supported: {list(KERNEL_TYPES)}"
+            )
+    return types
+
+
+def _angles_1d(angles: ArrayLike) -> np.ndarray:
+    """Validate and return the angle vector ``[theta_1, ..., theta_M]``."""
+    a = np.asarray(angles, dtype=float).reshape(-1)
+    if a.size == 0:
+        raise ValueError("angles must contain at least one angle")
+    return a
+
+
+def kronecker_angles(
+    N: int, angle: float = np.pi / 4, **overrides: float
+) -> np.ndarray:
+    """Angle vector ``[theta_1, ..., theta_M]`` for a network of size ``N``.
+
+    A convenience for the common case of "all kernels at one value, except a
+    named few".  ``theta_1`` is the innermost (even/odd) kernel and
+    ``theta_M`` the outermost (contiguous halves).
+
+    Parameters
+    ----------
+    N : int
+        Network size; must be a power of two.  ``M = log2(N)`` angles are
+        returned.
+    angle : float
+        Default value for every kernel (default ``pi / 4``, the
+        equal-mixing setting that yields Hadamard-like magnitudes).
+    **overrides : float
+        Per-kernel overrides given as ``theta1=..., theta2=...``, using the
+        paper's one-based indexing.  Negative indices are not supported;
+        use ``theta{M}`` for the outermost kernel.
+
+    Returns
+    -------
+    np.ndarray
+        Angles of shape ``(M,)``, ordered innermost to outermost.
+
+    Example::
+
+        # 32 channels, fully decoupled stereo halves (theta_M = 0)
+        kronecker_angles(32, theta5=0.0)
+    """
+    M = num_kernels(N)
+    a = np.full(M, float(angle))
+    for key, value in overrides.items():
+        if not key.startswith("theta"):
+            raise TypeError(f"Unexpected keyword argument {key!r}")
+        index = int(key.removeprefix("theta"))
+        if not 1 <= index <= M:
+            raise ValueError(f"{key!r} is out of range for N = {N} (M = {M})")
+        a[index - 1] = float(value)
+    return a
+
+
+def num_kernels(N: int) -> int:
+    """Number of kernels ``M = log2(N)``, raising unless ``N`` is a power of two."""
+    N = int(N)
+    if N < 2 or N & (N - 1):
+        raise ValueError(f"N must be a power of two and at least 2, got {N}")
+    return int(N).bit_length() - 1
+
+
+def kronecker_matrix(
+    angles: ArrayLike,
+    kernel_type: str | Sequence[str] = "rotation",
+) -> np.ndarray:
+    """Build the explicit Kronecker feedback matrix ``Psi_M``.
+
+    Formed by the recursion ``Psi_0 = 1``, ``Psi_m = K_m kron Psi_{m-1}``, so
+    ``angles[0]`` is the innermost kernel ``theta_1`` and ``angles[-1]`` the
+    outermost ``theta_M``.  The result is orthogonal for any angles.
+
+    Use this for analysis and plotting; for rendering prefer
+    :func:`kronecker_transform`, which never forms the matrix and costs
+    ``O(N log2 N)`` per input vector.
+
+    Parameters
+    ----------
+    angles : array-like
+        ``M`` kernel angles in radians, innermost first.
+    kernel_type : str or sequence of str
+        ``"rotation"`` or ``"reflection"``, either once for all kernels or one
+        per kernel (innermost first).
+
+    Returns
+    -------
+    np.ndarray
+        Orthogonal matrix of shape ``(2**M, 2**M)``.
+
+    Example::
+
+        >>> import numpy as np
+        >>> A = kronecker_matrix([np.pi / 4] * 3, "reflection")
+        >>> np.allclose(A @ A.T, np.eye(8))
+        True
+    """
+    a = _angles_1d(angles)
+    types = _normalise_kernel_types(kernel_type, a.size)
+
+    matrix = np.ones((1, 1))
+    for theta, name in zip(a, types, strict=True):
+        matrix = np.kron(_KERNELS[name](theta), matrix)
+    return matrix
+
+
+def kronecker_transform(
+    x: ArrayLike,
+    angles: ArrayLike,
+    kernel_type: str | Sequence[str] = "rotation",
+) -> np.ndarray:
+    """Apply the Kronecker feedback matrix to ``x`` in ``O(N log2 N)`` per row.
+
+    Equivalent to ``x @ kronecker_matrix(angles, kernel_type).T`` but computed
+    with the in-place divide-and-conquer butterfly of the paper's Algorithm 2:
+    ``M = log2(N)`` levels, each touching every sample once.  Level ``i`` mixes
+    the channel pairs that differ in bit ``i - 1`` of their index, which is
+    exactly the pairing kernel ``K_i`` addresses.
+
+    Angles may vary per sample, which is what makes an audio-rate modulated
+    feedback matrix cheap: only the modulated 2x2 kernel changes, never a
+    rebuilt ``N x N`` matrix.
+
+    Parameters
+    ----------
+    x : array-like
+        Signal of shape ``(N,)`` or ``(num_samples, N)``; the last axis is the
+        channel axis.
+    angles : array-like
+        ``M`` angles of shape ``(M,)`` for a fixed matrix, or
+        ``(num_samples, M)`` for one angle set per sample.
+    kernel_type : str or sequence of str
+        ``"rotation"`` or ``"reflection"``, either once for all kernels or one
+        per kernel (innermost first).
+
+    Returns
+    -------
+    np.ndarray
+        Mixed signal, same shape as ``x`` (2-D input stays 2-D).
+
+    Example::
+
+        >>> import numpy as np
+        >>> angles = np.full(3, np.pi / 4)
+        >>> x = np.random.randn(16, 8)
+        >>> fast = kronecker_transform(x, angles)
+        >>> np.allclose(fast, x @ kronecker_matrix(angles).T)
+        True
+    """
+    signal = np.asarray(x, dtype=float)
+    vector_input = signal.ndim == 1
+    if vector_input:
+        signal = signal[np.newaxis, :]
+    if signal.ndim != 2:
+        raise ValueError("x must be 1-D or 2-D (num_samples, channels)")
+
+    theta = np.asarray(angles, dtype=float)
+    if theta.ndim == 1:
+        theta = theta[np.newaxis, :]
+    if theta.ndim != 2:
+        raise ValueError("angles must be 1-D (M,) or 2-D (num_samples, M)")
+
+    num_samples, N = signal.shape
+    M = theta.shape[1]
+    if N != 1 << M:
+        raise ValueError(
+            f"x has {N} channels but {M} angles describe a {1 << M} matrix"
+        )
+    if theta.shape[0] not in (1, num_samples):
+        raise ValueError(
+            f"angles has {theta.shape[0]} rows, expected 1 or {num_samples}"
+        )
+    types = _normalise_kernel_types(kernel_type, M)
+
+    out = np.ascontiguousarray(signal, dtype=float)
+    if out is signal:
+        out = out.copy()
+
+    for level, name in enumerate(types):
+        stride = 1 << level  # pairs differ in bit `level` of the channel index
+        blocks = N // (2 * stride)
+        c = np.cos(theta[:, level])[:, np.newaxis, np.newaxis]
+        s = np.sin(theta[:, level])[:, np.newaxis, np.newaxis]
+
+        pairs = out.reshape(num_samples, blocks, 2, stride)
+        upper = pairs[:, :, 0, :]
+        lower = pairs[:, :, 1, :]
+        if name == "rotation":
+            mixed_upper = c * upper - s * lower
+            mixed_lower = s * upper + c * lower
+        else:  # reflection
+            mixed_upper = c * upper + s * lower
+            mixed_lower = s * upper - c * lower
+        pairs[:, :, 0, :] = mixed_upper
+        pairs[:, :, 1, :] = mixed_lower
+
+    return out[0] if vector_input else out

--- a/src/pyFDN/resources/references.bib
+++ b/src/pyFDN/resources/references.bib
@@ -149,6 +149,18 @@
   url = {https://pubs.aip.org/asa/jasa/article-abstract/138/3/1389/680169/Time-varying-feedback-matrices-in-feedback-delay?redirectedFrom=fulltext}
 }
 
+@inproceedings{Coppola2026FastParametric,
+  title = {Fast Parametric Matrices for Lossless Feedback Delay Networks},
+  booktitle = {Proceedings of the 29th International Conference on Digital Audio Effects (DAFx26)},
+  author = {Coppola, Andrea},
+  year = 2026,
+  month = sep,
+  pages = {32--39},
+  address = {Cambridge, MA, USA},
+  abstract = {This paper presents a framework for designing creative reverbs using parametric orthogonal feedback matrices on Feedback Delay Networks (FDNs) through recursive Kronecker products of 2D rotation and reflection matrices. By parameterizing each 2x2 kernel with a single angle, we construct a family of 2^M x 2^M orthogonal matrices that maintain losslessness while enabling continuous control over network topology. We then exploit their recursive definition to derive an efficient divide-and-conquer algorithm that computes the feedback operation with O(N log2 N) time complexity, matching the Fast Walsh-Hadamard Transform while offering parametric flexibility. Strategic manipulation of individual kernel angles enables creative sound design applications, such as stereo cross-coupling, selective freeze, and time-varying modulation for resonance breaking. The framework offers FDN designers an expressive, real-time tunable parametric matrix, balancing computational efficiency with intuitive control for creative reverberation design.},
+  url = {https://andrea-coppola-arturia.github.io/fastparametricmatrices/}
+}
+
 @article{Schroeder1961ColorlessArtificialReverberation,
   title = {"Colorless" Artificial Reverberation},
   author = {Schroeder, Manfred R and Logan, B F},

--- a/src/pyFDN/td/__init__.py
+++ b/src/pyFDN/td/__init__.py
@@ -37,6 +37,7 @@ from pyFDN.td.operators import (
     Gain,
     GranularPitchShift,
     Identity,
+    KroneckerMatrix,
     MatrixConvolver,
     MatrixFIR,
     PitchShift,
@@ -44,6 +45,7 @@ from pyFDN.td.operators import (
     RingModulator,
     SOSBank,
     TimeOperator,
+    TimeVaryingKroneckerMatrix,
     TimeVaryingMatrix,
 )
 
@@ -62,7 +64,9 @@ __all__ = [
     "SOSBank",
     "MatrixFIR",
     "MatrixConvolver",
+    "KroneckerMatrix",
     "TimeVaryingMatrix",
+    "TimeVaryingKroneckerMatrix",
     "RecursionState",
     "Series",
     "Parallel",

--- a/src/pyFDN/td/operators.py
+++ b/src/pyFDN/td/operators.py
@@ -17,12 +17,15 @@ delay lines.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import TypedDict
 
 import numpy as np
 from numpy.typing import ArrayLike
 from scipy.fft import irfft, next_fast_len, rfft
 from scipy.signal import lfilter, sosfilt
+
+from pyFDN.generate.kronecker_matrix import kronecker_transform
 
 
 def _as_2d(block: ArrayLike) -> np.ndarray:
@@ -954,6 +957,178 @@ class TimeVaryingMatrix(TimeOperator):
     def reset(self) -> None:
         # Rewind the modulation clock without re-drawing the random modulation
         # parameters, so a reset render is reproducible.
+        self.sample_index = 0
+
+
+class KroneckerMatrix(TimeOperator):
+    """Stateless Kronecker feedback matrix applied with the fast ``O(N log2 N)`` butterfly.
+
+    The operator form of :func:`pyFDN.kronecker_matrix`: an orthogonal
+    ``N x N`` mixing matrix (``N = 2**M``) described by ``M`` kernel angles,
+    applied without ever forming the matrix. Drop-in replacement for
+    ``Gain(kronecker_matrix(angles))`` that costs ``log2(N)`` butterfly levels
+    per sample instead of a dense matrix product.
+
+    See :class:`TimeVaryingKroneckerMatrix` for the modulated counterpart, and
+    :mod:`pyFDN.generate.kronecker_matrix` for what the individual angles
+    control.
+
+    Parameters
+    ----------
+    angles : array-like
+        ``M`` kernel angles in radians, innermost (``theta_1``, the even/odd
+        kernel) first.
+    kernel_type : str or sequence of str
+        ``"rotation"`` or ``"reflection"``, either once for all kernels or one
+        per kernel.
+
+    Example::
+
+        td.KroneckerMatrix(pyFDN.kronecker_angles(32, theta5=np.pi / 16))
+    """
+
+    def __init__(
+        self,
+        angles: ArrayLike,
+        kernel_type: str | Sequence[str] = "rotation",
+    ) -> None:
+        self.angles = np.asarray(angles, dtype=float).reshape(-1)
+        self.kernel_type = kernel_type
+        self.N = 1 << self.angles.size
+        self.in_channels = self.out_channels = self.N
+        # Validate the angle/kernel combination up front rather than on the
+        # first block.
+        kronecker_transform(np.zeros(self.N), self.angles, kernel_type)
+
+    def filter(self, block: ArrayLike) -> np.ndarray:
+        x = _as_2d(block)
+        if x.shape[1] != self.N:
+            raise ValueError(f"KroneckerMatrix expects {self.N} input channels")
+        return kronecker_transform(x, self.angles, self.kernel_type)
+
+
+class TimeVaryingKroneckerMatrix(TimeOperator):
+    """Kronecker feedback matrix with per-kernel angle modulation (time-varying feedback).
+
+    Each kernel angle follows ``theta_i(t) = angles[i] + depth[i] * w(2 * pi *
+    rate[i] * t + phase[i])`` with ``w`` a unit-amplitude sine or triangle, so
+    the matrix is orthogonal at every sample yet never constant. This is the
+    matrix modulation of Coppola (2026, Section 5.4): unlike delay-line
+    modulation it changes only the routing coefficients between delay lines,
+    which breaks up fixed modal resonances without the chorusing that
+    modulated delays introduce.
+
+    Because the angles are consumed by the fast butterfly, per-sample
+    modulation costs no more than the static matrix -- there is no ``N x N``
+    matrix to rebuild when an angle moves.
+
+    Sits on the feedback path of a :class:`~pyFDN.td.connectors.Recursion`, or
+    goes straight into the ``post_matrix`` argument of
+    :func:`pyFDN.process_fdn` with ``A`` left as the identity, in which case
+    this operator *is* the feedback matrix.
+
+    Parameters
+    ----------
+    angles : array-like
+        ``M`` unmodulated kernel angles in radians, innermost first. The
+        modulation is centred on these.
+    fs : float
+        Sampling rate in Hz; the modulation clock.
+    rate : float or array-like
+        Modulation frequency in Hz, one value or one per kernel.
+    depth : float or array-like
+        Modulation amplitude in radians, one value or one per kernel. Zero
+        leaves a kernel static, which is how a single level is singled out for
+        modulation (the paper modulates ``theta_{M-1}``).
+    phase : float or array-like
+        Initial modulation phase in radians, one value or one per kernel.
+    kernel_type : str or sequence of str
+        ``"rotation"`` or ``"reflection"``, either once for all kernels or one
+        per kernel.
+    waveform : {"sine", "triangle"}
+        Modulation shape.
+
+    Attributes
+    ----------
+    sample_index : int
+        Current sample index; the modulation clock. :meth:`reset` rewinds it.
+
+    Example::
+
+        # 16 channels, stereo halves decoupled, theta_3 modulated at 0.2 Hz
+        depth = [0.0, 0.0, 0.2 * np.pi, 0.0]
+        td.TimeVaryingKroneckerMatrix(
+            pyFDN.kronecker_angles(16, theta4=0.0), fs, rate=0.2, depth=depth
+        )
+    """
+
+    def __init__(
+        self,
+        angles: ArrayLike,
+        fs: float,
+        *,
+        rate: ArrayLike = 0.0,
+        depth: ArrayLike = 0.0,
+        phase: ArrayLike = 0.0,
+        kernel_type: str | Sequence[str] = "rotation",
+        waveform: str = "sine",
+    ) -> None:
+        self.angles = np.asarray(angles, dtype=float).reshape(-1)
+        self.num_kernels = self.angles.size
+        self.N = 1 << self.num_kernels
+        self.in_channels = self.out_channels = self.N
+        self.fs = float(fs)
+        self.kernel_type = kernel_type
+
+        if waveform not in ("sine", "triangle"):
+            raise ValueError(f"waveform must be 'sine' or 'triangle', got {waveform!r}")
+        self.waveform = waveform
+
+        self.rate = self._per_kernel(rate, "rate")
+        self.depth = self._per_kernel(depth, "depth")
+        self.phase = self._per_kernel(phase, "phase")
+
+        self.sample_index = 0
+        kronecker_transform(np.zeros(self.N), self.angles, kernel_type)
+
+    def _per_kernel(self, value: ArrayLike, name: str) -> np.ndarray:
+        """Broadcast a scalar or length-M sequence to one value per kernel."""
+        v = np.asarray(value, dtype=float).reshape(-1)
+        if v.size == 1:
+            return np.full(self.num_kernels, v.item())
+        if v.size != self.num_kernels:
+            raise ValueError(
+                f"{name} has {v.size} entries but there are {self.num_kernels} kernels"
+            )
+        return v
+
+    def angles_at(self, sample_indices: ArrayLike) -> np.ndarray:
+        """Kernel angles at the given sample indices, shape ``(len(indices), M)``.
+
+        Exposed so the modulation trajectory can be plotted or fed to
+        :func:`pyFDN.kronecker_matrix` for analysis without rendering audio.
+        """
+        n = np.asarray(sample_indices, dtype=float).reshape(-1, 1)
+        argument = 2 * np.pi * self.rate * (n / self.fs) + self.phase
+        if self.waveform == "sine":
+            shape = np.sin(argument)
+        else:  # triangle: unit amplitude, same period as the sine
+            shape = (2 / np.pi) * np.arcsin(np.sin(argument))
+        return self.angles + self.depth * shape
+
+    def filter(self, block: ArrayLike) -> np.ndarray:
+        x = _as_2d(block)
+        if x.shape[1] != self.N:
+            raise ValueError(
+                f"TimeVaryingKroneckerMatrix expects {self.N} input channels"
+            )
+        indices = self.sample_index + np.arange(x.shape[0])
+        out = kronecker_transform(x, self.angles_at(indices), self.kernel_type)
+        self.sample_index += x.shape[0]
+        return out
+
+    def reset(self) -> None:
+        """Rewind the modulation clock to sample zero."""
         self.sample_index = 0
 
 

--- a/tests/test_kronecker_matrix.py
+++ b/tests/test_kronecker_matrix.py
@@ -1,0 +1,378 @@
+"""Tests for the Kronecker feedback matrix (Coppola 2026) and its td operators."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.linalg import hadamard
+
+import pyFDN
+from pyFDN import td
+from pyFDN.generate.kronecker_matrix import num_kernels
+
+KERNEL_TYPES = ["rotation", "reflection"]
+
+
+@pytest.mark.parametrize("M", [1, 2, 3, 4, 5])  # type: ignore[misc]
+@pytest.mark.parametrize("kernel_type", KERNEL_TYPES)  # type: ignore[misc]
+def test_matrix_is_orthogonal_for_arbitrary_angles(M: int, kernel_type: str) -> None:
+    rng = np.random.default_rng(M)
+    A = pyFDN.kronecker_matrix(rng.uniform(-np.pi, np.pi, M), kernel_type)
+
+    assert A.shape == (2**M, 2**M)
+    assert np.allclose(A @ A.T, np.eye(2**M), atol=1e-12)
+
+
+@pytest.mark.parametrize("M", [1, 2, 3, 4, 5])  # type: ignore[misc]
+@pytest.mark.parametrize("kernel_type", KERNEL_TYPES)  # type: ignore[misc]
+def test_fast_transform_matches_explicit_matrix(M: int, kernel_type: str) -> None:
+    rng = np.random.default_rng(100 + M)
+    angles = rng.uniform(-np.pi, np.pi, M)
+    x = rng.standard_normal((16, 2**M))
+
+    fast = pyFDN.kronecker_transform(x, angles, kernel_type)
+
+    assert np.allclose(fast, x @ pyFDN.kronecker_matrix(angles, kernel_type).T)
+
+
+def test_fast_transform_accepts_mixed_kernel_types() -> None:
+    rng = np.random.default_rng(7)
+    angles = rng.uniform(-np.pi, np.pi, 4)
+    kernel_type = ["rotation", "reflection", "reflection", "rotation"]
+    x = rng.standard_normal((5, 16))
+
+    fast = pyFDN.kronecker_transform(x, angles, kernel_type)
+
+    assert np.allclose(fast, x @ pyFDN.kronecker_matrix(angles, kernel_type).T)
+
+
+def test_fast_transform_accepts_a_single_vector() -> None:
+    rng = np.random.default_rng(8)
+    angles = rng.uniform(-np.pi, np.pi, 3)
+    x = rng.standard_normal(8)
+
+    out = pyFDN.kronecker_transform(x, angles)
+
+    assert out.shape == (8,)
+    assert np.allclose(out, pyFDN.kronecker_matrix(angles) @ x)
+
+
+def test_fast_transform_leaves_the_input_untouched() -> None:
+    x = np.ones((4, 8))
+    original = x.copy()
+
+    pyFDN.kronecker_transform(x, np.full(3, 0.3))
+
+    assert np.array_equal(x, original)
+
+
+def test_per_sample_angles_match_a_per_sample_matrix() -> None:
+    rng = np.random.default_rng(9)
+    angles = rng.uniform(-np.pi, np.pi, (6, 3))
+    x = rng.standard_normal((6, 8))
+
+    fast = pyFDN.kronecker_transform(x, angles)
+
+    expected = np.stack(
+        [pyFDN.kronecker_matrix(angles[n]) @ x[n] for n in range(x.shape[0])]
+    )
+    assert np.allclose(fast, expected)
+
+
+@pytest.mark.parametrize("M", [2, 3, 4, 5])  # type: ignore[misc]
+def test_all_reflection_kernels_at_quarter_pi_give_hadamard(M: int) -> None:
+    """Section 5.1: Ref(pi/4) is H_2, so the Kronecker product is H_{2^M}."""
+    A = pyFDN.kronecker_matrix(np.full(M, np.pi / 4), "reflection")
+
+    assert np.allclose(A, hadamard(2**M) / np.sqrt(2**M), atol=1e-12)
+
+
+def test_rotation_kernels_at_quarter_pi_have_equal_magnitudes() -> None:
+    """Rot(pi/4) mixes with uniform energy, as Hadamard does but with signs of its own."""
+    N = 16
+    A = pyFDN.kronecker_matrix(pyFDN.kronecker_angles(N))
+
+    assert np.allclose(np.abs(A), 1 / np.sqrt(N))
+
+
+def test_outermost_angle_zero_decouples_the_contiguous_halves() -> None:
+    """Section 5.2: theta_M = 0 makes the matrix block diagonal (two stereo halves)."""
+    N = 16
+    A = pyFDN.kronecker_matrix(pyFDN.kronecker_angles(N, theta4=0.0))
+    half = N // 2
+
+    assert np.allclose(A[:half, half:], 0.0)
+    assert np.allclose(A[half:, :half], 0.0)
+    # ... and the two independent halves are themselves orthogonal.
+    assert np.allclose(A[:half, :half] @ A[:half, :half].T, np.eye(half))
+
+
+def test_outermost_angle_half_pi_is_purely_cross_coupled() -> None:
+    """theta_M = pi/2 leaves only the off-diagonal blocks: the halves swap."""
+    N = 16
+    A = pyFDN.kronecker_matrix(pyFDN.kronecker_angles(N, theta4=np.pi / 2))
+    half = N // 2
+
+    assert np.allclose(A[:half, :half], 0.0)
+    assert np.allclose(A[half:, half:], 0.0)
+
+
+def test_innermost_angle_zero_decouples_even_and_odd_lines() -> None:
+    """Section 5.3: theta_1 = 0 splits the network into even/odd subnetworks."""
+    N = 16
+    A = pyFDN.kronecker_matrix(pyFDN.kronecker_angles(N, theta1=0.0))
+    even, odd = np.arange(0, N, 2), np.arange(1, N, 2)
+
+    assert np.allclose(A[np.ix_(even, odd)], 0.0)
+    assert np.allclose(A[np.ix_(odd, even)], 0.0)
+
+
+def test_figure_5_matrix_combines_even_odd_and_stereo_partitioning() -> None:
+    """Figure 5: N = 8 rotation kernels at theta = (0, pi/4, pi/8)."""
+    A = pyFDN.kronecker_matrix([0.0, np.pi / 4, np.pi / 8])
+    even, odd = np.arange(0, 8, 2), np.arange(1, 8, 2)
+
+    # theta_1 = 0: no even/odd cross-talk.
+    assert np.allclose(A[np.ix_(even, odd)], 0.0)
+    # theta_3 = pi/8: partial, non-zero coupling between the two halves,
+    # of magnitude sin(pi/8) / sqrt(2) against sqrt(2) / 2 * cos(pi/8) within.
+    assert np.isclose(np.abs(A[:4, 4:]).max(), np.sin(np.pi / 8) / np.sqrt(2))
+    assert np.isclose(np.abs(A[:4, :4]).max(), np.cos(np.pi / 8) / np.sqrt(2))
+    # Figure 5 shows exactly the two magnitudes 0.27 and 0.65.
+    magnitudes = np.unique(np.round(np.abs(A[np.abs(A) > 1e-12]), 2))
+    assert np.allclose(magnitudes, [0.27, 0.65])
+
+
+def test_kronecker_angles_defaults_and_overrides() -> None:
+    angles = pyFDN.kronecker_angles(32, theta1=0.0, theta5=np.pi / 16)
+
+    assert angles.shape == (5,)
+    assert angles[0] == 0.0
+    assert angles[4] == np.pi / 16
+    assert np.allclose(angles[1:4], np.pi / 4)
+
+
+def test_kronecker_angles_rejects_out_of_range_kernels() -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        pyFDN.kronecker_angles(8, theta9=0.0)
+    with pytest.raises(TypeError, match="Unexpected keyword"):
+        pyFDN.kronecker_angles(8, gamma1=0.0)  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize("N", [3, 1, 12])  # type: ignore[misc]
+def test_num_kernels_requires_a_power_of_two(N: int) -> None:
+    with pytest.raises(ValueError, match="power of two"):
+        num_kernels(N)
+
+
+def test_transform_rejects_a_channel_count_that_does_not_match_the_angles() -> None:
+    with pytest.raises(ValueError, match="channels"):
+        pyFDN.kronecker_transform(np.zeros((4, 8)), np.zeros(2))
+
+
+def test_transform_rejects_an_angle_row_count_that_does_not_match_the_block() -> None:
+    with pytest.raises(ValueError, match="rows"):
+        pyFDN.kronecker_transform(np.zeros((4, 8)), np.zeros((3, 3)))
+
+
+def test_unknown_kernel_type_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unknown kernel_type"):
+        pyFDN.kronecker_matrix([0.1, 0.2], "shear")
+
+
+def test_kernels_are_the_paper_definitions() -> None:
+    assert np.allclose(pyFDN.rotation_kernel(0.0), np.eye(2))
+    assert np.allclose(pyFDN.reflection_kernel(0.0), np.diag([1.0, -1.0]))
+    assert np.allclose(
+        pyFDN.reflection_kernel(np.pi / 4), np.array([[1, 1], [1, -1]]) / np.sqrt(2)
+    )
+
+
+# --- gallery integration ----------------------------------------------------
+
+
+def test_gallery_lists_and_builds_the_kronecker_type() -> None:
+    assert "kronecker" in pyFDN.fdn_matrix_gallery()
+
+    A = pyFDN.fdn_matrix_gallery(8, "kronecker")
+    assert isinstance(A, np.ndarray)  # the gallery returns a name list when N is None
+
+    assert A.shape == (8, 8)
+    assert np.allclose(A @ A.T, np.eye(8))
+    assert np.allclose(A, pyFDN.kronecker_matrix(pyFDN.kronecker_angles(8)))
+
+
+def test_gallery_forwards_angles_and_kernel_type() -> None:
+    angles = [0.0, np.pi / 4, np.pi / 8]
+
+    A = pyFDN.fdn_matrix_gallery(
+        8, "kronecker", angles=angles, kernel_type="reflection"
+    )
+
+    assert np.allclose(A, pyFDN.kronecker_matrix(angles, "reflection"))
+
+
+def test_gallery_kronecker_requires_a_power_of_two_size() -> None:
+    with pytest.raises(ValueError, match="power of two"):
+        pyFDN.fdn_matrix_gallery(6, "kronecker")
+
+
+# --- td operators -----------------------------------------------------------
+
+
+def test_kronecker_matrix_operator_matches_a_static_gain() -> None:
+    rng = np.random.default_rng(11)
+    angles = rng.uniform(-np.pi, np.pi, 4)
+    x = rng.standard_normal((32, 16))
+
+    operator = td.KroneckerMatrix(angles)
+
+    assert operator.in_channels == operator.out_channels == 16
+    assert np.allclose(
+        operator.process(x), td.Gain(pyFDN.kronecker_matrix(angles)).process(x)
+    )
+
+
+def test_kronecker_matrix_operator_is_block_invariant() -> None:
+    rng = np.random.default_rng(12)
+    angles = rng.uniform(-np.pi, np.pi, 3)
+    x = rng.standard_normal((30, 8))
+    operator = td.KroneckerMatrix(angles)
+
+    whole = operator.process(x)
+    streamed = np.vstack([operator.filter(x[i : i + 7]) for i in range(0, 30, 7)])
+
+    assert np.allclose(whole, streamed)
+
+
+def test_kronecker_matrix_operator_rejects_a_channel_mismatch() -> None:
+    with pytest.raises(ValueError, match="expects 8 input channels"):
+        td.KroneckerMatrix(np.zeros(3)).process(np.zeros((4, 4)))
+
+
+def test_time_varying_operator_is_orthogonal_at_every_sample() -> None:
+    fs = 48000.0
+    operator = td.TimeVaryingKroneckerMatrix(
+        pyFDN.kronecker_angles(16, theta4=0.0), fs, rate=2.0, depth=np.pi
+    )
+
+    for angles in operator.angles_at([0, 137, 6000, 24000]):
+        A = pyFDN.kronecker_matrix(angles)
+        assert np.allclose(A @ A.T, np.eye(16), atol=1e-12)
+
+
+def test_time_varying_operator_follows_the_paper_modulation_law() -> None:
+    """Section 5.4: theta_{M-1}(t) = pi/4 + depth * sin(2 pi rate t)."""
+    fs, rate, depth = 48000.0, 0.2, 0.2 * np.pi
+    operator = td.TimeVaryingKroneckerMatrix(
+        pyFDN.kronecker_angles(16, theta4=0.0),
+        fs,
+        rate=[0.0, 0.0, rate, 0.0],
+        depth=[0.0, 0.0, depth, 0.0],
+    )
+
+    n = np.arange(0, int(fs), 997)
+    angles = operator.angles_at(n)
+
+    assert np.allclose(
+        angles[:, 2], np.pi / 4 + depth * np.sin(2 * np.pi * rate * n / fs)
+    )
+    # Unmodulated kernels stay put, theta_M included.
+    assert np.allclose(angles[:, [0, 1]], np.pi / 4)
+    assert np.allclose(angles[:, 3], 0.0)
+
+
+def test_time_varying_operator_advances_and_rewinds_its_clock() -> None:
+    fs = 48000.0
+    operator = td.TimeVaryingKroneckerMatrix(
+        pyFDN.kronecker_angles(8), fs, rate=1.0, depth=0.5
+    )
+    x = np.random.default_rng(13).standard_normal((64, 8))
+
+    first = operator.process(x)
+    assert operator.sample_index == 64
+
+    second = operator.process(x)
+    assert not np.allclose(first, second)
+
+    operator.reset()
+    assert np.allclose(operator.process(x), first)
+
+
+def test_zero_depth_time_varying_operator_equals_the_static_matrix() -> None:
+    angles = pyFDN.kronecker_angles(8, theta1=0.3)
+    x = np.random.default_rng(14).standard_normal((20, 8))
+
+    modulated = td.TimeVaryingKroneckerMatrix(angles, 48000.0, rate=3.0, depth=0.0)
+
+    assert np.allclose(modulated.process(x), td.KroneckerMatrix(angles).process(x))
+
+
+def test_triangle_waveform_stays_within_the_requested_depth() -> None:
+    operator = td.TimeVaryingKroneckerMatrix(
+        pyFDN.kronecker_angles(8), 48000.0, rate=1.0, depth=np.pi, waveform="triangle"
+    )
+
+    angles = operator.angles_at(np.arange(48000))
+    excursion = angles - np.pi / 4
+
+    assert np.isclose(excursion.max(), np.pi, atol=1e-3)
+    assert np.isclose(excursion.min(), -np.pi, atol=1e-3)
+
+
+def test_unknown_waveform_is_rejected() -> None:
+    with pytest.raises(ValueError, match="waveform"):
+        td.TimeVaryingKroneckerMatrix(np.zeros(3), 48000.0, waveform="saw")
+
+
+def test_modulation_parameter_length_is_checked() -> None:
+    with pytest.raises(ValueError, match="depth has 2 entries"):
+        td.TimeVaryingKroneckerMatrix(np.zeros(3), 48000.0, depth=[0.1, 0.2])
+
+
+def test_kronecker_feedback_matrix_renders_a_lossless_fdn() -> None:
+    """A Kronecker matrix in place of A keeps the undamped FDN energy-preserving."""
+    N = 8
+    delays = pyFDN.sample_delay_lengths(N, (60, 300), coprime=True, rng=3)
+    A = pyFDN.kronecker_matrix(pyFDN.kronecker_angles(N, theta2=0.7))
+    B = np.ones((N, 1)) / np.sqrt(N)
+    C = np.ones((1, N)) / np.sqrt(N)
+    D = np.zeros((1, 1))
+
+    impulse = np.zeros(4000)
+    impulse[0] = 1.0
+    ir = pyFDN.process_fdn(impulse, delays, A, B, C, D)
+
+    # Lossless: the tail neither grows nor dies away.
+    assert np.isfinite(ir).all()
+    late = np.asarray(ir).reshape(-1)[2000:]
+    assert np.abs(late).max() > 1e-3
+
+
+def test_time_varying_kronecker_matrix_drives_process_fdn() -> None:
+    """With A = I the operator on ``post_matrix`` *is* the feedback matrix."""
+    N = 16
+    delays = pyFDN.sample_delay_lengths(N, (60, 300), coprime=True, rng=4)
+    fs = 48000.0
+    modulated = td.TimeVaryingKroneckerMatrix(
+        pyFDN.kronecker_angles(N, theta4=0.0),
+        fs,
+        rate=[0.0, 0.0, 2.0, 0.0],
+        depth=[0.0, 0.0, np.pi, 0.0],
+    )
+    static = td.KroneckerMatrix(pyFDN.kronecker_angles(N, theta4=0.0))
+
+    impulse = np.zeros(8000)
+    impulse[0] = 1.0
+    common = (
+        delays,
+        np.eye(N),
+        np.ones((N, 1)) / np.sqrt(N),
+        np.ones((1, N)) / np.sqrt(N),
+        np.zeros((1, 1)),
+    )
+    moving = pyFDN.process_fdn(impulse, *common, post_matrix=modulated)
+    fixed = pyFDN.process_fdn(impulse, *common, post_matrix=static)
+
+    assert np.isfinite(moving).all()
+    assert not np.allclose(moving, fixed)


### PR DESCRIPTION
Implements the Kronecker Feedback Matrix of Coppola, *Fast parametric matrices for lossless feedback delay networks* (DAFx26, pp. 32–39), together with its companion site's demonstrations.

## What it is

An `N x N` feedback matrix with `N = 2**M` written as a Kronecker product of `M` two-by-two rotation or reflection kernels, one angle each:

```
Psi_M = K_M ⊗ K_{M-1} ⊗ … ⊗ K_1
```

Kronecker products of orthogonal matrices are orthogonal, so **every** setting of every angle is lossless — the angles can be swept or modulated at audio rate and the FDN never stops being energy-preserving, with no re-orthogonalisation anywhere.

What makes the angles useful rather than merely safe is that each kernel addresses one bit of the delay-line index, so a single angle cuts or re-couples the network along one partition: `theta_M` across the two contiguous halves (stereo cross-coupling), `theta_1` between the even- and odd-indexed lines, and the levels in between at intermediate granularities.

## API

`src/pyFDN/generate/kronecker_matrix.py`:

- `rotation_kernel` / `reflection_kernel` — the paper's `Rot(theta)` and half-angle `Ref(theta)`.
- `kronecker_matrix(angles, kernel_type)` — the explicit matrix via `Psi_m = K_m ⊗ Psi_{m-1}`, angles innermost first, mixed kernel families allowed.
- `kronecker_transform(x, angles, kernel_type)` — the paper's Algorithm 2 in-place butterfly at `O(N log2 N)`, vectorised over a block. It accepts **per-sample angles** of shape `(num_samples, M)`, which is what makes audio-rate modulation cost the same as a static matrix: a moving angle changes one 2x2 kernel rather than rebuilding an `N x N` matrix.
- `kronecker_angles(N, angle, **theta_i)` — "all kernels at `pi/4` except the ones you name".

All reflection kernels at `pi/4` recover the normalised Hadamard matrix, so the usual FDN mixing matrix is one point in the family and the parameterisation morphs continuously away from it.

Reachable from the gallery as `fdn_matrix_gallery(N, "kronecker")`, which takes keyword-only `angles` and `kernel_type`.

Two `td` operators go with it:

- `td.KroneckerMatrix` — a fixed angle set, applied with the fast transform.
- `td.TimeVaryingKroneckerMatrix` — modulates chosen kernel angles by a sine or triangle, which breaks up fixed modal resonances by moving the poles without the chorusing that modulating the delay lengths brings, since it changes only the routing coefficients. `angles_at()` exposes the trajectory for analysis.

Both drop into the `post_matrix` hook of `process_fdn`, where with `A` carrying the absorption alone the operator *is* the feedback matrix.

## Notebook

`example_kronecker_matrix` (gallery: Feedback Matrices) reproduces the configurations from the paper's companion site — the construction and its Hadamard special case, the fast transform, the stereo cross-coupling sweep on `theta_M` with interchannel-balance and IACC analysis, and matrix modulation on `theta_{M-1}` with the pole-frequency histogram of Figure 6, where the bin-count spread roughly halves under modulation, the same direction and order as the paper reports.

Selective freeze is left out. It switches the input gains and absorption at runtime rather than constructing a matrix, so it belongs with the time-varying-gain machinery; the notebook says so and why.

## Two things the notebook deliberately does not claim

- **IACC does not discriminate the coupling settings** with 32 distinct coprime delays. The two halves are structurally independent, so the tail decorrelates to about 0.04 at every non-zero coupling — which is exactly what the companion site states ("for all coupled settings the reverberant tail decorrelates toward a low steady-state value"), but not the richer traces of the paper's Figure 4. Reproducing those needs the two halves to share delay lengths, which the site's "all coprime" description rules out. IACC is kept because it is the paper's metric, and an interchannel-balance plot is added because that is what actually visualises the sweep with this delay set.
- **The NumPy timing table does not show the asymptotic win.** BLAS beats a five-level Python-loop butterfly on 4096-sample blocks at these sizes. The transform is exact to machine precision, and the speedup is attributed to the paper's per-sample C++ setting rather than claimed here.

## Verification

Verified against the paper: the matrix reproduces **Figure 5 entry for entry**, all-reflection-at-`pi/4` equals the normalised Hadamard matrix, and `theta_M = 0` / `theta_1 = 0` give the contiguous-half and even/odd decouplings.

`tests/test_kronecker_matrix.py` adds 57 tests covering orthogonality for arbitrary angles, fast-transform equivalence to the explicit matrix (including mixed kernel types and per-sample angles), the structural decouplings, the gallery integration, and both `td` operators. Full suite: 477 passed, 1 skipped, including all 42 example notebooks.

Also: `Coppola2026FastParametric` added to the packaged bibliography, `docs/api_reference.rst` and `HISTORY.rst` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdAAH724cqM7WCfNvPQ3uL
