### PR TITLE
fix(dss_to_ss): support documented minimum delay of 3 samples

### DIFF
--- a/src/pyFDN/translate/dss_to_ss.py
+++ b/src/pyFDN/translate/dss_to_ss.py
@@ -41,6 +41,12 @@ def dss_to_ss(
     A = np.asarray(A)
     N = A.shape[0]
 
+    if np.any(m_arr < 3):
+        raise ValueError(
+            "All delays in `m` must be at least 3 samples, "
+            f"got minimum {int(m_arr.min())}."
+        )
+
     # Default gains
     if b is None:
         b = np.ones((N, 1))
@@ -54,12 +60,14 @@ def dss_to_ss(
     R = np.zeros((0, N))  # start with 0 rows
 
     for it in range(N):
-        # U_j: (m_arr[it]-3) x (m_arr[it]-3) with 1's on first superdiagonal
+        # U_j: (m_arr[it]-2) x (m_arr[it]-2) with 1's on first superdiagonal.
+        # np.diag(np.ones(n), 1) has shape (n+1, n+1), so passing
+        # size_Uj = m_arr[it] - 3 directly (including the size_Uj == 0 case,
+        # which yields the (1, 1) zero block needed for the minimum delay of
+        # 3 samples) already produces the correct (m_arr[it]-2, m_arr[it]-2)
+        # block, matching the sizes of the corresponding P_j/R_j blocks.
         size_Uj = m_arr[it] - 3
-        if size_Uj > 0:
-            U_j = np.diag(np.ones(size_Uj), 1)
-        else:
-            U_j = np.zeros((0, 0))
+        U_j = np.diag(np.ones(size_Uj), 1)
         U_blocks.append(U_j)
 
         # R_j: (m_arr[it]-2) x N, last row = 1 at column it

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -10,8 +10,8 @@ from pyFDN.translate.dss_to_ss import dss_to_ss
 from pyFDN.translate.dss_to_tf import dss_to_tf
 
 
-def test_dss_to_ss_raises_for_inconsistent_delay_blocks():
-    delays = np.array([3, 4])
+def test_dss_to_ss_raises_for_delay_below_minimum():
+    delays = np.array([2, 4])
     A = np.eye(2)
     bb = np.ones((2, 1))
     cc = np.ones((1, 2))
@@ -19,6 +19,32 @@ def test_dss_to_ss_raises_for_inconsistent_delay_blocks():
 
     with pytest.raises(ValueError):
         dss_to_ss(delays, A, bb, cc, dd)
+
+
+def test_dss_to_ss_supports_mixed_delays_including_minimum():
+    # Regression test for #240: delays that mix the documented minimum of
+    # 3 samples with larger delays must not raise a shape-mismatch error.
+    delays = np.array([3, 4])
+    A = np.eye(2)
+    bb = np.ones((2, 1))
+    cc = np.ones((1, 2))
+    dd = np.eye(1)
+
+    AA, _, _, _ = dss_to_ss(delays, A, bb, cc, dd)
+
+    total = int(np.sum(delays))
+    assert AA.shape == (total, total)
+
+
+def test_dss_to_ss_handles_minimum_delay_of_three():
+    # Regression test for #240: m=[3] previously raised a dimension
+    # mismatch instead of returning a (3, 3) state-space matrix.
+    AA, bb, cc, dd = dss_to_ss(m=np.array([3]), A=np.array([[0.5]]))
+
+    assert AA.shape == (3, 3)
+    assert bb.shape == (3, 1)
+    assert cc.shape == (1, 3)
+    assert dd.shape == (1, 1)
 
 
 def test_dss_to_impz_produces_delayed_impulse():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #240.

`dss_to_ss` raised a dimension-mismatch `ValueError` whenever any delay in `m` equalled the documented minimum of 3 samples (e.g. `m=[3]`), instead of returning a valid state-space realization.

## Root cause

For each delay `m_i`, the code builds three blocks that must all share the same size, `m_i - 2`:
- `U_j` (via `np.diag(np.ones(m_i - 3), 1)`, which has shape `(m_i - 2, m_i - 2)`)
- `R_j` (shape `(m_i - 2, N)`)
- `P_j` (shape `(N, m_i - 2)`)

The code special-cased `size_Uj == 0` (i.e. `m_i == 3`) to produce a `(0, 0)` block for `U_j` instead of letting `np.diag(np.ones(0), 1)` produce the correct `(1, 1)` zero block. That mismatch propagated into `np.hstack`/`np.vstack` calls and raised `ValueError: all the input array dimensions except for the concatenation axis must match exactly`.

## Fix

- Removed the incorrect `size_Uj == 0` special case; `np.diag(np.ones(size_Uj), 1)` already produces the correct `(m_i - 2, m_i - 2)` block for every valid delay, including the minimum of 3 samples.
- Added an explicit `ValueError` with a clear message when any delay in `m` is below the documented minimum of 3 samples (previously this would surface as a confusing internal `numpy` shape error).

## Tests

- Updated `test_dss_to_ss_raises_for_inconsistent_delay_blocks` (renamed to `test_dss_to_ss_raises_for_delay_below_minimum`), which was actually pinning this exact bug with `delays=[3, 4]` — a valid input that should not raise.
- Added `test_dss_to_ss_supports_mixed_delays_including_minimum` to confirm delay vectors mixing the minimum (3) with larger delays now succeed.
- Added `test_dss_to_ss_handles_minimum_delay_of_three`, a direct regression test for the exact repro from the issue (`m=[3]`, single-channel `A`), asserting `AA.shape == (3, 3)`.

Full test suite passes locally (`370 passed, 2 skipped`, excluding an unrelated pre-existing collection error in `tests/test_marimo_examples_run.py` caused by a missing `plotly` import in this environment, unrelated to this change).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06ea4-3b1b-7e36-b68c-0b28d7d328c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06ea4-3b1b-7e36-b68c-0b28d7d328c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

